### PR TITLE
Fixed dockerfile build context settings

### DIFF
--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -18,7 +18,12 @@ services:
 
     sqe-http:
         container_name: SQE_HTTP_API
-        build: ./
+        build:
+            # Since the Dockerfile is no longer at the root, reset the context two folder higher from this docker-compose.yml
+            # It would provide a more optimized build if the context folder contained only "data-access" and "sqe-http-api".
+            context: ../../
+            # Provide the relative path from the context to the Dockerfile
+            dockerfile: docker/Dockerfile
         restart: always
         ports:
             - 5000:5000


### PR DESCRIPTION
Moving the docker files to another folder broke their build process.  I have added the necessary context settings in the docker-compose.yml for proper building of the container.  The autobuild settings on DockerHub have also been updated accordingly and are now tested and working.