### PR TITLE
Transient error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
 
 script:
 - dotnet build
-- dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='../coverage.xml' /p:Exclude="[xunit.*]*%2c[*]SQE.SqeHttpApi.Server.Helpers.EmailSender%2c[*]SQE.SqeHttpApi.Server.Helpers.StartupChecks%2c[*]SQE.SqeHttpApi.Server.Program%2c[*]SQE.SqeHttpApi.DataAccess.Helpers.ApiException%2c[*]SQE.SqeHttpApi.DataAccess.Helpers.StandardErrors"
+- dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput='../coverage.xml' /p:Exclude="[xunit.*]*%2c[*]SQE.SqeHttpApi.Server.Helpers.EmailSender%2c[*]SQE.SqeHttpApi.Server.Helpers.StartupChecks%2c[*]SQE.SqeHttpApi.Server.Program%2c[*]SQE.SqeHttpApi.DataAccess.Helpers.ApiException%2c[*]SQE.SqeHttpApi.DataAccess.Helpers.StandardErrors%2c[*]SQE.SqeHttpApi.DataAccess.DbConnectionBase.ReliableMySqlDbCommand%2c[*]SQE.SqeHttpApi.DataAccess.DbConnectionBase.ReliableMySqlConnection"
 - ~/.dotnet/tools/csmacnz.Coveralls --opencover -i ./coverage.xml --commitId $TRAVIS_COMMIT --commitBranch $TRAVIS_BRANCH --commitAuthor "$REPO_COMMIT_AUTHOR" --commitEmail "$REPO_COMMIT_AUTHOR_EMAIL" --commitMessage "$REPO_COMMIT_MESSAGE" --jobId $TRAVIS_JOB_ID  --serviceName "travis-ci" --useRelativePaths

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SQE_API
 
-[![Build Status](https://travis-ci.org/Scripta-Qumranica-Electronica/SQE_API.svg?branch=integration-tests)](https://travis-ci.org/Scripta-Qumranica-Electronica/SQE_API)
-[![Coverage Status](https://coveralls.io/repos/github/Scripta-Qumranica-Electronica/SQE_API/badge.svg?branch=integration-tests)](https://coveralls.io/github/Scripta-Qumranica-Electronica/SQE_API?branch=integration-tests)
+[![Build Status](https://travis-ci.org/Scripta-Qumranica-Electronica/SQE_API.svg?branch=development)](https://travis-ci.org/Scripta-Qumranica-Electronica/SQE_API)
+[![Coverage Status](https://coveralls.io/repos/github/Scripta-Qumranica-Electronica/SQE_API/badge.svg?branch=development)](https://coveralls.io/github/Scripta-Qumranica-Electronica/SQE_API?branch=integration-tests)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Scripta-Qumranica-Electronica/SQE_API/blob/master/LICENSE.txt)
 
 Asp.Net Core web API for the [SQE project](https://www.qumranica.org/). 

--- a/api-test/ArtefactTest.cs
+++ b/api-test/ArtefactTest.cs
@@ -168,6 +168,8 @@ namespace SQE.ApiTest
                 $"/{version}/editions/{newEdition}/{controller}/{artefact.id}", null, 
                 await HttpRequest.GetJWTAsync(_client));
             Assert.Equal(HttpStatusCode.NotFound, delResponse.StatusCode);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -251,6 +253,8 @@ namespace SQE.ApiTest
             Assert.Equal(artefact.mask.mask, updatedAllArtefact.mask.mask);
             Assert.Equal(otherTransform, updatedAllArtefact.mask.transformMatrix);
             Assert.Equal(artefact.name, updatedAllArtefact.name);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
 
         #endregion Access artefacts (should succeed)
@@ -286,6 +290,8 @@ namespace SQE.ApiTest
             
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -306,6 +312,8 @@ namespace SQE.ApiTest
             
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -332,6 +340,8 @@ namespace SQE.ApiTest
             
             // Assert (update name)
             Assert.Equal(HttpStatusCode.Unauthorized, nameResponse.StatusCode);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -359,6 +369,8 @@ namespace SQE.ApiTest
             
             // Assert (update name)
             Assert.Equal(HttpStatusCode.BadRequest, nameResponse.StatusCode);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -386,6 +398,8 @@ namespace SQE.ApiTest
             
             // Assert (update name)
             Assert.Equal(HttpStatusCode.BadRequest, nameResponse.StatusCode);
+
+            await HttpRequest.DeleteEdition(_client, newEdition, true);
         }
         #endregion Access artefacts (should fail)
         

--- a/api-test/ArtefactTest.cs
+++ b/api-test/ArtefactTest.cs
@@ -62,7 +62,7 @@ namespace SQE.ApiTest
         {
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
-            var newEdition = await HttpRequest.CreateNewEdition(_client, allArtefacts.First().editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, allArtefacts.First().editionId); // Clone it
 
             const string masterImageSQL = "SELECT sqe_image_id FROM SQE_image WHERE type = 0 ORDER BY RAND() LIMIT 1";
             var masterImageId = await _db.RunQuerySingleAsync<uint>(masterImageSQL, null);
@@ -152,7 +152,7 @@ namespace SQE.ApiTest
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
             var artefact = allArtefacts.First();
-            var newEdition = await HttpRequest.CreateNewEdition(_client, artefact.editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, artefact.editionId); // Clone it
             
             // Act
             var (response, writtenArtefact) = await HttpRequest.SendAsync<string, string>(_client, HttpMethod.Delete,
@@ -169,7 +169,7 @@ namespace SQE.ApiTest
                 await HttpRequest.GetJWTAsync(_client));
             Assert.Equal(HttpStatusCode.NotFound, delResponse.StatusCode);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -182,7 +182,7 @@ namespace SQE.ApiTest
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
             var artefact = allArtefacts.First();
-            var newEdition = await HttpRequest.CreateNewEdition(_client, artefact.editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, artefact.editionId); // Clone it
             var newArtefactName = _faker.Random.Words(5);
             var newArtefactPosition = RandomPosition();
             const string newArtefactShape = "POLYGON((0 0,0 200,200 200,0 200,0 0),(5 5,5 25,25 25,25 5,5 5),(77 80,77 92,102 92,102 80,77 80))";
@@ -254,7 +254,7 @@ namespace SQE.ApiTest
             Assert.Equal(otherTransform, updatedAllArtefact.mask.transformMatrix);
             Assert.Equal(artefact.name, updatedAllArtefact.name);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
 
         #endregion Access artefacts (should succeed)
@@ -269,7 +269,7 @@ namespace SQE.ApiTest
         {
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
-            var newEdition = await HttpRequest.CreateNewEdition(_client, allArtefacts.First().editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, allArtefacts.First().editionId); // Clone it
 
             const string masterImageSQL = "SELECT sqe_image_id FROM SQE_image WHERE type = 0 ORDER BY RAND() LIMIT 1";
             var masterImageId = await _db.RunQuerySingleAsync<uint>(masterImageSQL, null);
@@ -291,7 +291,7 @@ namespace SQE.ApiTest
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -304,7 +304,7 @@ namespace SQE.ApiTest
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
             var artefact = allArtefacts.First();
-            var newEdition = await HttpRequest.CreateNewEdition(_client, artefact.editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, artefact.editionId); // Clone it
             
             // Act
             var (response, _) = await HttpRequest.SendAsync<string, string>(_client, HttpMethod.Delete,
@@ -313,7 +313,7 @@ namespace SQE.ApiTest
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -326,7 +326,7 @@ namespace SQE.ApiTest
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
             var artefact = allArtefacts.First();
-            var newEdition = await HttpRequest.CreateNewEdition(_client, artefact.editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, artefact.editionId); // Clone it
             var newArtefactName = _faker.Random.Words(5);
             
             // Act (update name)
@@ -341,7 +341,7 @@ namespace SQE.ApiTest
             // Assert (update name)
             Assert.Equal(HttpStatusCode.Unauthorized, nameResponse.StatusCode);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -354,7 +354,7 @@ namespace SQE.ApiTest
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
             var artefact = allArtefacts.First();
-            var newEdition = await HttpRequest.CreateNewEdition(_client, artefact.editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, artefact.editionId); // Clone it
             const string newArtefactShape = "POLYGON(0 0,0 200,200 200,0 200,0 0),5 5,5 25,25 25,25 5,5 5),(77 80,77 92,102 92,102 80,77 80))";
             
             // Act (update name)
@@ -370,7 +370,7 @@ namespace SQE.ApiTest
             // Assert (update name)
             Assert.Equal(HttpStatusCode.BadRequest, nameResponse.StatusCode);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
         
         /// <summary>
@@ -383,7 +383,7 @@ namespace SQE.ApiTest
             // Arrange
             var allArtefacts = (await GetRandomEditionArtefacts()).artefacts; // Find edition with artefacts
             var artefact = allArtefacts.First();
-            var newEdition = await HttpRequest.CreateNewEdition(_client, artefact.editionId); // Clone it
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, artefact.editionId); // Clone it
             var newArtefactMatrix = RandomPosition(properlyFormatted: false);
             
             // Act (update name)
@@ -399,7 +399,7 @@ namespace SQE.ApiTest
             // Assert (update name)
             Assert.Equal(HttpStatusCode.BadRequest, nameResponse.StatusCode);
 
-            await HttpRequest.DeleteEdition(_client, newEdition, true);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true);
         }
         #endregion Access artefacts (should fail)
         

--- a/api-test/DbConnectionBaseTest.cs
+++ b/api-test/DbConnectionBaseTest.cs
@@ -24,11 +24,11 @@ namespace SQE.ApiTest
             var counter = new Counter() { Count = 0 };
             const uint code = 1205;
             const int minExecutionTime = 2500; // Currently 200 factorial 5 - minimum random offset (100 * 5)
-            var policy = new DatabaseCommunicationRetryPolicy();
+            
             var watch = System.Diagnostics.Stopwatch.StartNew();
             
             // Act
-            var ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlException(counter, code)));
+            var ex = Assert.Throws<MySqlException>(() => DatabaseCommunicationRetryPolicy.ExecuteRetry(() => ThrowMySqlException(counter, code)));
             
             // Assert
             watch.Stop();
@@ -42,7 +42,7 @@ namespace SQE.ApiTest
             watch = System.Diagnostics.Stopwatch.StartNew();
             
             // Act
-            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => DatabaseCommunicationRetryPolicy.ExecuteRetry(() => ThrowMySqlExceptionWithReturn(counter, code)));
             
             // Assert
             watch.Stop();
@@ -57,7 +57,7 @@ namespace SQE.ApiTest
             var token = new CancellationToken();
             
             // Act
-            ex = await Assert.ThrowsAsync<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlExceptionAsync(counter, code), token));
+            ex = await Assert.ThrowsAsync<MySqlException>(() => DatabaseCommunicationRetryPolicy.ExecuteRetry(() => ThrowMySqlExceptionAsync(counter, code), token));
             
             // Assert
             watch.Stop();
@@ -71,7 +71,7 @@ namespace SQE.ApiTest
             watch = System.Diagnostics.Stopwatch.StartNew();
             
             // Act
-            ex = await Assert.ThrowsAsync<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            ex = await Assert.ThrowsAsync<MySqlException>(() => DatabaseCommunicationRetryPolicy.ExecuteRetry(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
             
             // Assert
             watch.Stop();
@@ -86,11 +86,10 @@ namespace SQE.ApiTest
             // Arrange
             var counter = new Counter() { Count = 0 };
             const uint code = 1203;
-            var policy = new DatabaseCommunicationRetryPolicy();
             var watch = System.Diagnostics.Stopwatch.StartNew();
             
             // Act
-            var ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlException(counter, code)));
+            var ex = Assert.Throws<MySqlException>(() => DatabaseCommunicationRetryPolicy.ExecuteRetry(() => ThrowMySqlException(counter, code)));
             
             // Assert
             watch.Stop();
@@ -104,7 +103,7 @@ namespace SQE.ApiTest
             // Arrange
             var counter = new Counter() { Count = 0 };
             const uint code = 1040;
-            var policy = new DatabaseCommunicationRetryPolicy();
+            var policy = new DatabaseCommunicationCircuitBreakPolicy();
             
             // Act (even though we run this 7 times, the method itself should only run 5 times total)
             var retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
@@ -121,7 +120,7 @@ namespace SQE.ApiTest
             
             // With return type
             // Arrange
-            policy = new DatabaseCommunicationRetryPolicy();
+            policy = new DatabaseCommunicationCircuitBreakPolicy();
             counter.Count = 0;
             
             // Act (even though we run this 7 times, the method itself should only run 5 times total)
@@ -140,7 +139,7 @@ namespace SQE.ApiTest
             // Async
             // Arrange
             counter.Count = 0;
-            policy = new DatabaseCommunicationRetryPolicy();
+            policy = new DatabaseCommunicationCircuitBreakPolicy();
             var token = new CancellationToken();
             
             // Act (even though we run this 7 times, the method itself should only run 5 times total)
@@ -158,7 +157,7 @@ namespace SQE.ApiTest
             
             // Async with return
             // Arrange
-            policy = new DatabaseCommunicationRetryPolicy();
+            policy = new DatabaseCommunicationCircuitBreakPolicy();
             counter.Count = 0;
             
             // Act (even though we run this 7 times, the method itself should only run 5 times total)
@@ -181,7 +180,7 @@ namespace SQE.ApiTest
             // Arrange
             var counter = new Counter() { Count = 0 };
             const uint code = 1044;
-            var policy = new DatabaseCommunicationRetryPolicy();
+            var policy = new DatabaseCommunicationCircuitBreakPolicy();
             
             // Act (we run this 7 times and the circuit breaker should not engage)
             var ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));

--- a/api-test/DbConnectionBaseTest.cs
+++ b/api-test/DbConnectionBaseTest.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using Polly.CircuitBreaker;
+using SQE.SqeHttpApi.DataAccess;
+using Xunit;
+
+namespace SQE.ApiTest
+{
+    public class DbConnectionBaseTest
+    {
+        // TODO: probably we should have tests for ReliableMySqlConnection and ReliableMySqlDbCommand
+        // They are in use and all other tests pass, but some things, like ReliableMySqlDbCommand.Prepare() or 
+        // ReliableMySqlConnection.DataSource, never get tested (I don't necessarily know what they all should do).
+        // Perhaps something could be wrong there and we would not see it for a very long time.
+        
+        [Fact]
+        public async Task RetryPoliciesShouldRepeat()
+        {
+            // Arrange
+            var counter = new Counter() { Count = 0 };
+            const uint code = 1205;
+            const int minExecutionTime = 2500; // Currently 200 factorial 5 - minimum random offset (100 * 5)
+            var policy = new DatabaseCommunicationRetryPolicy();
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            
+            // Act
+            var ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlException(counter, code)));
+            
+            // Assert
+            watch.Stop();
+            Assert.Equal(code, ex.Code);
+            Assert.Equal(6, counter.Count); // This should have tried a total of 6 times.
+            Assert.True(watch.ElapsedMilliseconds > minExecutionTime);
+            
+            // With return type
+            // Arrange
+            counter = new Counter() { Count = 0 };
+            watch = System.Diagnostics.Stopwatch.StartNew();
+            
+            // Act
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            
+            // Assert
+            watch.Stop();
+            Assert.Equal(code, ex.Code);
+            Assert.Equal(6, counter.Count); // This should have tried a total of 6 times.
+            Assert.True(watch.ElapsedMilliseconds > minExecutionTime);
+            
+            // With Async
+            // Arrange
+            counter = new Counter() { Count = 0 };
+            watch = System.Diagnostics.Stopwatch.StartNew();
+            var token = new CancellationToken();
+            
+            // Act
+            ex = await Assert.ThrowsAsync<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlExceptionAsync(counter, code), token));
+            
+            // Assert
+            watch.Stop();
+            Assert.Equal(code, ex.Code);
+            Assert.Equal(6, counter.Count); // This should have tried a total of 6 times.
+            Assert.True(watch.ElapsedMilliseconds > minExecutionTime);
+            
+            // Async with return type
+            // Arrange
+            counter = new Counter() { Count = 0 };
+            watch = System.Diagnostics.Stopwatch.StartNew();
+            
+            // Act
+            ex = await Assert.ThrowsAsync<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            
+            // Assert
+            watch.Stop();
+            Assert.Equal(code, ex.Code);
+            Assert.Equal(6, counter.Count); // This should have tried a total of 6 times.
+            Assert.True(watch.ElapsedMilliseconds > minExecutionTime);
+        }
+        
+        [Fact]
+        public async Task RetryPoliciesShouldNotRepeat()
+        {
+            // Arrange
+            var counter = new Counter() { Count = 0 };
+            const uint code = 1203;
+            var policy = new DatabaseCommunicationRetryPolicy();
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            
+            // Act
+            var ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetry(() => ThrowMySqlException(counter, code)));
+            
+            // Assert
+            watch.Stop();
+            Assert.Equal(code, ex.Code);
+            Assert.Equal(1, counter.Count); // This should have tried a total of 6 times.
+        }
+        
+        [Fact]
+        public async Task ShortCircuitShouldEngage()
+        {
+            // Arrange
+            var counter = new Counter() { Count = 0 };
+            const uint code = 1040;
+            var policy = new DatabaseCommunicationRetryPolicy();
+            
+            // Act (even though we run this 7 times, the method itself should only run 5 times total)
+            var retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            
+            // Assert
+            Assert.Equal(code, ((MySqlException) retryEx.InnerException).Code);
+            Assert.Equal(5, counter.Count); // This should have tried a total of 5 times, before the breaker engaged.
+            
+            // With return type
+            // Arrange
+            policy = new DatabaseCommunicationRetryPolicy();
+            counter.Count = 0;
+            
+            // Act (even though we run this 7 times, the method itself should only run 5 times total)
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            retryEx = Assert.Throws<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturn(counter, code)));
+            
+            // Assert
+            Assert.Equal(code, ((MySqlException) retryEx.InnerException).Code);
+            Assert.Equal(5, counter.Count); // This should have tried a total of 5 times, before the breaker engaged.
+            
+            // Async
+            // Arrange
+            counter.Count = 0;
+            policy = new DatabaseCommunicationRetryPolicy();
+            var token = new CancellationToken();
+            
+            // Act (even though we run this 7 times, the method itself should only run 5 times total)
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionAsync(counter, code), token));
+            
+            // Assert
+            Assert.Equal(code, ((MySqlException) retryEx.InnerException).Code);
+            Assert.Equal(5, counter.Count); // This should have tried a total of 5 times, before the breaker engaged.
+            
+            // Async with return
+            // Arrange
+            policy = new DatabaseCommunicationRetryPolicy();
+            counter.Count = 0;
+            
+            // Act (even though we run this 7 times, the method itself should only run 5 times total)
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            retryEx = await Assert.ThrowsAsync<BrokenCircuitException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlExceptionWithReturnAsync(counter, code), token));
+            
+            // Assert
+            Assert.Equal(code, ((MySqlException) retryEx.InnerException).Code);
+            Assert.Equal(5, counter.Count); // This should have tried a total of 5 times, before the breaker engaged.
+        }
+        
+        [Fact]
+        public async Task ShortCircuitShouldNotEngage()
+        {
+            // Arrange
+            var counter = new Counter() { Count = 0 };
+            const uint code = 1044;
+            var policy = new DatabaseCommunicationRetryPolicy();
+            
+            // Act (we run this 7 times and the circuit breaker should not engage)
+            var ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            ex = Assert.Throws<MySqlException>(() => policy.ExecuteRetryWithCircuitBreaker(() => ThrowMySqlException(counter, code)));
+            
+            // Assert
+            Assert.Equal(code, ex.Code);
+            Assert.Equal(7, counter.Count); // This should have tried a total of 5 times, before the breaker engaged.
+        }
+
+        private static void ThrowMySqlException(Counter counter, uint sqlErrorCode)
+        {
+            counter.Count += 1;
+            var mySqlExceptionType = typeof(MySqlException).GetTypeInfo();
+            var internalConstructor = (from consInfo in mySqlExceptionType.DeclaredConstructors
+                let paramInfos = consInfo.GetParameters()
+                where paramInfos.Length == 3 && 
+                      paramInfos[0].ParameterType == typeof(uint) && 
+                      paramInfos[1].ParameterType == typeof(string) && 
+                      paramInfos[2].ParameterType == typeof(string)
+                select consInfo).Single();
+ 
+            var exception = internalConstructor.Invoke(new object[] { sqlErrorCode, "Nothing done.", "deadlock" }) as Exception;
+            throw exception;
+        }
+        
+        private static string ThrowMySqlExceptionWithReturn(Counter counter, uint sqlErrorCode)
+        {
+            counter.Count += 1;
+            var mySqlExceptionType = typeof(MySqlException).GetTypeInfo();
+            var internalConstructor = (from consInfo in mySqlExceptionType.DeclaredConstructors
+                let paramInfos = consInfo.GetParameters()
+                where paramInfos.Length == 3 && 
+                      paramInfos[0].ParameterType == typeof(uint) && 
+                      paramInfos[1].ParameterType == typeof(string) && 
+                      paramInfos[2].ParameterType == typeof(string)
+                select consInfo).Single();
+ 
+            var exception = internalConstructor.Invoke(new object[] { sqlErrorCode, "Nothing done.", "deadlock" }) as Exception;
+            throw exception;
+        }
+        
+        private static async Task ThrowMySqlExceptionAsync(Counter counter, uint sqlErrorCode)
+        {
+            counter.Count += 1;
+            var mySqlExceptionType = typeof(MySqlException).GetTypeInfo();
+            var internalConstructor = (from consInfo in mySqlExceptionType.DeclaredConstructors
+                let paramInfos = consInfo.GetParameters()
+                where paramInfos.Length == 3 && 
+                      paramInfos[0].ParameterType == typeof(uint) && 
+                      paramInfos[1].ParameterType == typeof(string) && 
+                      paramInfos[2].ParameterType == typeof(string)
+                select consInfo).Single();
+ 
+            var exception = internalConstructor.Invoke(new object[] { sqlErrorCode, "Nothing done.", "deadlock" }) as Exception;
+            throw exception;
+        }
+        
+        private static async Task<string> ThrowMySqlExceptionWithReturnAsync(Counter counter, uint sqlErrorCode)
+        {
+            counter.Count += 1;
+            var mySqlExceptionType = typeof(MySqlException).GetTypeInfo();
+            var internalConstructor = (from consInfo in mySqlExceptionType.DeclaredConstructors
+                let paramInfos = consInfo.GetParameters()
+                where paramInfos.Length == 3 && 
+                      paramInfos[0].ParameterType == typeof(uint) && 
+                      paramInfos[1].ParameterType == typeof(string) && 
+                      paramInfos[2].ParameterType == typeof(string)
+                select consInfo).Single();
+ 
+            var exception = internalConstructor.Invoke(new object[] { sqlErrorCode, "Nothing done.", "deadlock" }) as Exception;
+            throw exception;
+        }
+
+        private class Counter
+        {
+            public int Count { get; set; }
+        }
+    }
+}

--- a/api-test/EditionTests.cs
+++ b/api-test/EditionTests.cs
@@ -164,7 +164,7 @@ namespace SQE.ApiTest
         {
             // ARRANGE
             var bearerToken = await HttpRequest.GetJWTAsync(_client);
-            var editionId = await HttpRequest.CreateNewEdition(_client);
+            var editionId = await EditionHelpers.CreateCopyOfEdition(_client);
             var url = "/v1/editions/" + editionId;
             var (response, msg) = await HttpRequest.SendAsync<string, EditionGroupDTO>(
                 _client, 
@@ -203,7 +203,7 @@ namespace SQE.ApiTest
         {
             // ARRANGE
             var bearerToken = await HttpRequest.GetJWTAsync(_client);
-            var editionId = await HttpRequest.CreateNewEdition(_client);
+            var editionId = await EditionHelpers.CreateCopyOfEdition(_client);
             const string url = "/v1/editions";
             
             // Act (get listings with authentication)
@@ -243,7 +243,7 @@ namespace SQE.ApiTest
         public async Task CanDeleteEditionAsAdmin()
         {
             // Arrange
-            var editionId = await HttpRequest.CreateNewEdition(_client);
+            var editionId = await EditionHelpers.CreateCopyOfEdition(_client);
             const string url = "/v1/editions";
             
             // Act
@@ -258,7 +258,7 @@ namespace SQE.ApiTest
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode); // Should fail without confirmation
             
             // Delete the edition for real
-            await HttpRequest.DeleteEdition(_client, editionId, true, true);
+            await EditionHelpers.DeleteEdition(_client, editionId, true, true);
             var (editionResponse, editionMsg) = await HttpRequest.SendAsync<string, EditionListDTO>(
                 _client, 
                 HttpMethod.Get, 
@@ -275,7 +275,7 @@ namespace SQE.ApiTest
         public async Task CanNotDeleteEditionWhenAnonymous()
         {
             // Arrange
-            var editionId = await HttpRequest.CreateNewEdition(_client);
+            var editionId = await EditionHelpers.CreateCopyOfEdition(_client);
             const string url = "/v1/editions";
             
             // Act
@@ -298,7 +298,7 @@ namespace SQE.ApiTest
             var editionMatch = editionMsg.editions.SelectMany(x => x).Where(x => x.id == editionId);
             Assert.Single(editionMatch);
 
-            await HttpRequest.DeleteEdition(_client, editionId, true);
+            await EditionHelpers.DeleteEdition(_client, editionId, true);
         }
 
         #region Edition Editor Permissions
@@ -311,10 +311,10 @@ namespace SQE.ApiTest
         
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -359,10 +359,10 @@ namespace SQE.ApiTest
         
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -408,10 +408,10 @@ namespace SQE.ApiTest
         
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -456,10 +456,10 @@ namespace SQE.ApiTest
         {
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -506,10 +506,10 @@ namespace SQE.ApiTest
         {
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -582,10 +582,10 @@ namespace SQE.ApiTest
         {
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -640,7 +640,7 @@ namespace SQE.ApiTest
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, delete2Response.StatusCode); // Should fail for last admin
             // Kill the edition for real
-            await HttpRequest.DeleteEdition(_client, newEdition, true, true, user1.email, user1Pwd);
+            await EditionHelpers.DeleteEdition(_client, newEdition, true, true, user1.email, user1Pwd);
             var (user1Resp2, user1Msg2) = await HttpRequest.SendAsync<string, EditionGroupDTO>(_client,
                 HttpMethod.Get,
                 $"/v1/editions/{newEdition}", null,
@@ -661,10 +661,10 @@ namespace SQE.ApiTest
         
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,
@@ -690,10 +690,10 @@ namespace SQE.ApiTest
         
             // Arrange
             const string user1Pwd = "pwd1";
-            var user1 = await HttpRequest.CreateRandomUser(_client, user1Pwd);
+            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
             const string user2Pwd = "pwd2";
-            var user2 = await HttpRequest.CreateRandomUser(_client, user2Pwd);
-            var newEdition = await HttpRequest.CreateNewEdition(_client, username: user1.email, pwd: user1Pwd);
+            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client, username: user1.email, pwd: user1Pwd);
             var newPermissions = new EditorRightsDTO()
             {
                 email = user2.email,

--- a/api-test/EditionTests.cs
+++ b/api-test/EditionTests.cs
@@ -231,6 +231,36 @@ namespace SQE.ApiTest
             Assert.True(msg.editions.Count > 0);
             Assert.DoesNotContain(msg.editions.SelectMany(x => x), x => x.id == editionId);
         }
+
+        // TODO: write the rest of the tests.
+        [Fact]
+        public async Task CanDeleteEditionAsAdmin()
+        {
+            // Arrange
+            var editionId = await HttpRequest.CreateNewEdition(_client);
+            const string url = "/v1/editions";
+            
+            // Act
+            var (response, msg) = await HttpRequest.SendAsync<string, string>(
+                _client, 
+                HttpMethod.Delete, 
+                url + "/" + editionId.ToString(), 
+                null, 
+                await HttpRequest.GetJWTAsync(_client));
+            
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var (editionResponse, editionMsg) = await HttpRequest.SendAsync<string, EditionListDTO>(
+                _client, 
+                HttpMethod.Get, 
+                url, 
+                null, 
+                await HttpRequest.GetJWTAsync(_client));
+            editionResponse.EnsureSuccessStatusCode();
+            var editionMatch = editionMsg.editions.SelectMany(x => x).Where(x => x.id == editionId);
+            Assert.Empty(editionMatch);
+        }
         
         
         

--- a/api-test/EditionTests.cs
+++ b/api-test/EditionTests.cs
@@ -255,8 +255,10 @@ namespace SQE.ApiTest
                 await HttpRequest.GetJWTAsync(_client));
             
             // Assert
-            response.EnsureSuccessStatusCode();
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode); // Should fail without confirmation
+            
+            // Delete the edition for real
+            await HttpRequest.DeleteEdition(_client, editionId, true, true);
             var (editionResponse, editionMsg) = await HttpRequest.SendAsync<string, EditionListDTO>(
                 _client, 
                 HttpMethod.Get, 
@@ -266,8 +268,6 @@ namespace SQE.ApiTest
             editionResponse.EnsureSuccessStatusCode();
             var editionMatch = editionMsg.editions.SelectMany(x => x).Where(x => x.id == editionId);
             Assert.Empty(editionMatch);
-
-            await HttpRequest.DeleteEdition(_client, editionId, true);
         }
         
         // TODO: need sharing capability before this can be tested properly
@@ -638,7 +638,9 @@ namespace SQE.ApiTest
                 await HttpRequest.GetJWTAsync(_client, user1.email, user1Pwd));
             
             // Assert
-            delete2Response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.BadRequest, delete2Response.StatusCode); // Should fail for last admin
+            // Kill the edition for real
+            await HttpRequest.DeleteEdition(_client, newEdition, true, true, user1.email, user1Pwd);
             var (user1Resp2, user1Msg2) = await HttpRequest.SendAsync<string, EditionGroupDTO>(_client,
                 HttpMethod.Get,
                 $"/v1/editions/{newEdition}", null,

--- a/api-test/EditionTests.cs
+++ b/api-test/EditionTests.cs
@@ -351,7 +351,6 @@ namespace SQE.ApiTest
             Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
             Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
             user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
-            user1Msg.primary.owner.ShouldDeepEqual(user2Msg.primary.owner);
         }
         
         [Fact]
@@ -401,7 +400,6 @@ namespace SQE.ApiTest
             Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
             Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
             user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
-            user1Msg.primary.owner.ShouldDeepEqual(user2Msg.primary.owner);
         }
         
         [Fact]
@@ -451,7 +449,6 @@ namespace SQE.ApiTest
             Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
             Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
             user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
-            user1Msg.primary.owner.ShouldDeepEqual(user2Msg.primary.owner);
         }
         
         [Fact]
@@ -502,7 +499,6 @@ namespace SQE.ApiTest
             Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
             Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
             user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
-            user1Msg.primary.owner.ShouldDeepEqual(user2Msg.primary.owner);
         }
         
         [Fact]
@@ -555,10 +551,9 @@ namespace SQE.ApiTest
             share2Response.EnsureSuccessStatusCode();
             Assert.True(share2Msg.mayRead);
             Assert.True(share2Msg.mayWrite);
-            Assert.False(shareMsg.mayLock);
+            Assert.False(share2Msg.mayLock);
             Assert.True(share2Msg.isAdmin);
             
-            // TODO: I am receiving the wrong permissions here, figure it out.
             var (user2Resp2, user2Msg2) = await HttpRequest.SendAsync<string, EditionGroupDTO>(_client,
                 HttpMethod.Get,
                 $"/v1/editions/{newEdition}", null,

--- a/api-test/EditionTests.cs
+++ b/api-test/EditionTests.cs
@@ -260,6 +260,39 @@ namespace SQE.ApiTest
             editionResponse.EnsureSuccessStatusCode();
             var editionMatch = editionMsg.editions.SelectMany(x => x).Where(x => x.id == editionId);
             Assert.Empty(editionMatch);
+
+            await HttpRequest.DeleteEdition(_client, editionId, true);
+        }
+        
+        // TODO: need sharing capability before this can be tested properly
+        [Fact]
+        public async Task CanNotDeleteEditionWhenNotAdmin()
+        {
+            // Arrange
+            var editionId = await HttpRequest.CreateNewEdition(_client);
+            const string url = "/v1/editions";
+            
+            // Act
+            var (response, msg) = await HttpRequest.SendAsync<string, string>(
+                _client, 
+                HttpMethod.Delete, 
+                url + "/" + editionId.ToString(), 
+                null, 
+                null);
+            
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            var (editionResponse, editionMsg) = await HttpRequest.SendAsync<string, EditionListDTO>(
+                _client, 
+                HttpMethod.Get, 
+                url, 
+                null, 
+                await HttpRequest.GetJWTAsync(_client));
+            editionResponse.EnsureSuccessStatusCode();
+            var editionMatch = editionMsg.editions.SelectMany(x => x).Where(x => x.id == editionId);
+            Assert.Single(editionMatch);
+
+            await HttpRequest.DeleteEdition(_client, editionId, true);
         }
         
         

--- a/api-test/Helpers/EditionHelpers.cs
+++ b/api-test/Helpers/EditionHelpers.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bogus;
 using Dapper;
 using SQE.SqeHttpApi.Server.DTOs;
+using Xunit;
 
 namespace SQE.ApiTest.Helpers
 {
@@ -18,7 +19,7 @@ namespace SQE.ApiTest.Helpers
         /// </summary>
         /// <param name="userId">Id of the user whose editions should be randomly selected.</param>
         /// <param name="jwt">A JWT can be added the request to access private editions.</param>
-        /// <returns></returns>
+        /// <returns>a randomly selected EditionDTO</returns>
         public static async Task<EditionDTO> GetRandomEdition(DatabaseQuery db, HttpClient client, uint userId = 1, string jwt = null)
         {
             const string sql = @"
@@ -40,6 +41,52 @@ WHERE user_id = @UserId";
             }
 
             return editionResponse.primary;
+        }
+        
+        /// <summary>
+        /// Creates a new edition. This will be a copy of editionId 1 if no other editionId is entered.
+        /// </summary>
+        /// <param name="client">The HttpClient</param>
+        /// <param name="editionId">Optional id of the edition to be cloned</param>
+        /// <param name="username">Optional username for the user who will own the edition</param>
+        /// <param name="pwd">Optional password for the user who will own the edition</param>
+        /// <returns>The ID of the new edition</returns>
+        public static async Task<uint> CreateCopyOfEdition(HttpClient client, uint editionId = 1, string username = null, 
+            string pwd = null)
+        {
+            var newScrollRequest = new EditionUpdateRequestDTO("test-name", null, null);
+            var (response, msg) = await HttpRequest.SendAsync<EditionUpdateRequestDTO, EditionDTO>(client, HttpMethod.Post, 
+                $"/v1/editions/{editionId}", newScrollRequest, await HttpRequest.GetJWTAsync(client, username, pwd));
+            response.EnsureSuccessStatusCode();
+            return msg.id;
+        }
+        
+        /// <summary>
+        /// Deletes an edition for all editors.
+        /// </summary>
+        /// <param name="client">The HttpClient</param>
+        /// <param name="editionId"></param>
+        /// <param name="authenticated">Optional, whether the request should be made by an authenticated user</param>
+        /// <param name="shouldSucceed">Optional, whether the delete action is expected to succeed</param>
+        /// <param name="email">Optional, the email of the user who is admin for the edition</param>
+        /// <param name="pwd">Optional, the password of the user who is admin for the edition</param>
+        /// <returns>void</returns>
+        public static async Task DeleteEdition(HttpClient client, uint editionId, bool authenticated = false, 
+            bool shouldSucceed = true, string email = null, string pwd = null)
+        {
+            var (response, msg) = await HttpRequest.SendAsync<string, DeleteTokenDTO>(client, HttpMethod.Delete, 
+                $"/v1/editions/{editionId}?optional=deleteForAllEditors", null, authenticated ? await HttpRequest.GetJWTAsync(client, email, pwd) : null);
+            if (shouldSucceed)
+            {
+                response.EnsureSuccessStatusCode();
+                Assert.NotNull(msg.token);
+                Assert.Equal(editionId, msg.editionId);
+                var (response2, msg2) = await HttpRequest.SendAsync<string, DeleteTokenDTO>(client, HttpMethod.Delete, 
+                    $"/v1/editions/{msg.editionId}?optional=deleteForAllEditors&token={msg.token}", null, 
+                    authenticated ? await HttpRequest.GetJWTAsync(client, email, pwd) : null);
+                response2.EnsureSuccessStatusCode();
+                Assert.Null(msg2);
+            }
         }
     }
 }

--- a/api-test/Helpers/HttpRequest.cs
+++ b/api-test/Helpers/HttpRequest.cs
@@ -82,13 +82,12 @@ namespace SQE.ApiTest.Helpers
             return msg.id;
         }
         
-        // TODO: the controller needs to be created first.
-        public static async Task<uint> DeleteEdition(HttpClient client, uint editionId)
+        public static async Task DeleteEdition(HttpClient client, uint editionId, bool authenticated = false, bool shouldSucceed = true)
         {
-            var newScrollRequest = new EditionUpdateRequestDTO("test-name", null, null);
-            var (response, msg) = await SendAsync<EditionUpdateRequestDTO, EditionDTO>(client, HttpMethod.Post, $"/v1/editions/{editionId}", newScrollRequest, await GetJWTAsync(client));
-            response.EnsureSuccessStatusCode();
-            return msg.id;
+            var (response, msg) = await SendAsync<EditionUpdateRequestDTO, EditionDTO>(client, HttpMethod.Delete, 
+                $"/v1/editions/{editionId}", null, authenticated ? await GetJWTAsync(client) : null);
+            if (shouldSucceed)
+                response.EnsureSuccessStatusCode();
         }
     }
 }

--- a/api-test/Helpers/HttpRequest.cs
+++ b/api-test/Helpers/HttpRequest.cs
@@ -4,8 +4,11 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using Dapper;
 using Newtonsoft.Json;
 using SQE.SqeHttpApi.Server.DTOs;
+using Xunit;
+using Bogus;
 
 namespace SQE.ApiTest.Helpers
 { 
@@ -64,20 +67,22 @@ namespace SQE.ApiTest.Helpers
             return (response: response, msg: parsedClass);
         }
         
-        public static async Task<string> GetJWTAsync(HttpClient client)
+        public static async Task<string> GetJWTAsync(HttpClient client, string username = null, string pwd = null)
         {
-            const string name = "test";
-            const string password = "asdf";
+            var name = username ?? "test";
+            var password = pwd ?? "asdf";
             var login = new LoginRequestDTO(){ email = name, password = password};
             var (response, msg) = await SendAsync<LoginRequestDTO, DetailedUserTokenDTO>(client, HttpMethod.Post, "/v1/users/login", login);
             response.EnsureSuccessStatusCode();
             return msg.token;
         }
 
-        public static async Task<uint> CreateNewEdition(HttpClient client, uint editionId = 1)
+        public static async Task<uint> CreateNewEdition(HttpClient client, uint editionId = 1, string username = null, 
+            string pwd = null)
         {
             var newScrollRequest = new EditionUpdateRequestDTO("test-name", null, null);
-            var (response, msg) = await SendAsync<EditionUpdateRequestDTO, EditionDTO>(client, HttpMethod.Post, $"/v1/editions/{editionId}", newScrollRequest, await GetJWTAsync(client));
+            var (response, msg) = await SendAsync<EditionUpdateRequestDTO, EditionDTO>(client, HttpMethod.Post, 
+                $"/v1/editions/{editionId}", newScrollRequest, await GetJWTAsync(client, username, pwd));
             response.EnsureSuccessStatusCode();
             return msg.id;
         }
@@ -89,5 +94,117 @@ namespace SQE.ApiTest.Helpers
             if (shouldSucceed)
                 response.EnsureSuccessStatusCode();
         }
+        
+        #region User Account Conveniences
+
+        public static async Task<DetailedUserDTO> CreateRandomUser(HttpClient client, string password)
+        {
+            var faker = new Faker("en");
+            var user = new NewUserRequestDTO(faker.Internet.Email(), password, faker.Company.CompanyName(), 
+                faker.Name.FirstName(), faker.Name.LastName());
+
+            var (userAcctResp, userAcctMsg) = await CreateUserAccountAsync(client, user);
+            userAcctResp.EnsureSuccessStatusCode();
+
+            await ActivateUserAccountAsync(client, userAcctMsg);
+            return userAcctMsg;
+        }
+        
+        private static async Task<(HttpResponseMessage response, DetailedUserDTO msg)> CreateUserAccountAsync(HttpClient client,
+            NewUserRequestDTO user, bool shouldSucceed = true)
+        {
+            var (response, msg) = await HttpRequest.SendAsync<NewUserRequestDTO, DetailedUserDTO>(client, 
+                HttpMethod.Post, "/v1/users", user);
+
+            // Assert
+            if (shouldSucceed)
+            {
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(user.email, msg.email);
+                Assert.Equal(user.forename, msg.forename);
+                Assert.Equal(user.surname, msg.surname);
+                Assert.Equal(user.organization, msg.organization);
+            }
+            else
+            {
+                Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+            }
+            return (response, msg);
+        }
+
+        private static async Task ActivateUserAccountAsync(HttpClient client, DetailedUserDTO user, bool shouldSucceed = true)
+        {
+            var userToken = await GetToken(user.email); // Get  token from DB
+            var payload = new AccountActivationRequestDTO() {token = userToken.token};
+            
+            var (response, msg) =
+                await HttpRequest.SendAsync<AccountActivationRequestDTO, UserDTO>(client, HttpMethod.Post, 
+                    "/v1/users/confirm-registration", payload);
+            
+            // Assert
+            if (shouldSucceed)
+            {
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+                var confirmedUser = await GetUserByEmail(user.email);
+                Assert.Equal(user.email, confirmedUser.email);
+                Assert.True(confirmedUser.activated);
+            }
+            else
+            {
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            }
+        }
+        
+        private static async Task<UserObj> GetUserByEmail(string email, bool shouldSucceed = true)
+        {
+            var db = new DatabaseQuery();
+            const string checkForUserSQL = "SELECT * FROM user WHERE email = @Email";
+            
+            var checkForUserSQLParams = new DynamicParameters();
+            checkForUserSQLParams.Add("@Email", email);
+            if (shouldSucceed)
+                return await db.RunQuerySingleAsync<UserObj>(checkForUserSQL, checkForUserSQLParams); // Get user from DB
+            
+            var users = await db.RunQueryAsync<UserObj>(checkForUserSQL, checkForUserSQLParams); // Get user from DB
+            Assert.Empty(users);
+            return new UserObj();
+        }
+        
+        private static async Task<Token> GetToken(string email, bool shouldSucceed = true)
+        {
+            var db = new DatabaseQuery();
+            const string getNewUserTokenSQL = "SELECT token, date_created, type FROM user_email_token JOIN user USING(user_id) WHERE email = @Email";
+            
+            var checkForUserSQLParams = new DynamicParameters();
+            checkForUserSQLParams.Add("@Email", email);
+            
+            if (shouldSucceed)
+                return await db.RunQuerySingleAsync<Token>(getNewUserTokenSQL, checkForUserSQLParams); // Get  token from DB
+            
+            var tokens = await db.RunQueryAsync<Token>(getNewUserTokenSQL, checkForUserSQLParams);
+            Assert.Empty(tokens);
+            return new Token();
+        }
+        
+        private class UserObj
+        {
+            public string email { get; set; }
+            public string password { get; set; }
+            public string forename { get; set; }
+            public string surname { get; set; }
+            public string organization { get; set; }
+            public bool activated { get; set; }
+            public uint user_id { get; set; }
+        }
+        
+        private class Token
+        {
+            public string token { get; set; }
+            public string type { get; set; }
+            public DateTime date_created { get; set; }
+        }
+        
+        #endregion User Account Conveniences
     }
 }

--- a/api-test/Helpers/ListHelpers.cs
+++ b/api-test/Helpers/ListHelpers.cs
@@ -7,6 +7,12 @@ namespace SQE.ApiTest.Helpers
     {
         private static readonly Faker _faker = new Faker("en");
 
+        /// <summary>
+        /// This randomly selects an entity from a list and return it.
+        /// </summary>
+        /// <param name="list">List from which one entity will be randomly selected</param>
+        /// <typeparam name="T">The type of the entities in the list</typeparam>
+        /// <returns>Returns an entity of type T.</returns>
         public static int RandomIdx<T>(List<T> list)
         {
             return list.Count > 1 ? _faker.Random.Number(0, list.Count - 1) : 0;

--- a/api-test/Helpers/UserHelpers.cs
+++ b/api-test/Helpers/UserHelpers.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Dapper;
+using SQE.SqeHttpApi.Server.DTOs;
+using SQE.SqeHttpApi.DataAccess.Queries;
+using Xunit;
+using Bogus;
+
+namespace SQE.ApiTest.Helpers
+{
+    public class UserHelpers
+    {
+        /// <summary>
+        /// Create a user with random information.
+        /// </summary>
+        /// <param name="client">The HttpClient</param>
+        /// <param name="password">The password for the newly created user.</param>
+        /// <returns>Returns a DetailedUserDTO object describing the new user.</returns>
+        public static async Task<DetailedUserDTO> CreateRandomUserAsync(HttpClient client, string password)
+        {
+            var faker = new Faker("en");
+            var user = new NewUserRequestDTO(faker.Internet.Email(), password, faker.Company.CompanyName(), 
+                faker.Name.FirstName(), faker.Name.LastName());
+
+            var userAcctMsg = await CreateUserAccountAsync(client, user);
+
+            await ActivateUserAccountAsync(client, userAcctMsg);
+            return userAcctMsg;
+        }
+        
+        /// <summary>
+        /// Creates a user account with the specified details.
+        /// </summary>
+        /// <param name="client">The HttpClient</param>
+        /// <param name="user">A NewUserRequestDTO object with the details of the new user to be created</param>
+        /// <param name="shouldSucceed">Optional, whether the action should succeed</param>
+        /// <returns>Returns a DetailedUserDTO for the newly created user.</returns>
+        private static async Task<DetailedUserDTO> CreateUserAccountAsync(HttpClient client,
+            NewUserRequestDTO user, bool shouldSucceed = true)
+        {
+            var (response, msg) = await HttpRequest.SendAsync<NewUserRequestDTO, DetailedUserDTO>(client, 
+                HttpMethod.Post, "/v1/users", user);
+
+            // Assert
+            if (shouldSucceed)
+            {
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(user.email, msg.email);
+                Assert.Equal(user.forename, msg.forename);
+                Assert.Equal(user.surname, msg.surname);
+                Assert.Equal(user.organization, msg.organization);
+            }
+            else
+            {
+                Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+            }
+            return msg;
+        }
+
+        /// <summary>
+        /// Activates a newly created user account.
+        /// </summary>
+        /// <param name="client">The HttpClient</param>
+        /// <param name="user">The DetailedUserDTO for the user whose account will be activated</param>
+        /// <param name="shouldSucceed">Optional, whether the action should succeed</param>
+        /// <returns>void</returns>
+        private static async Task ActivateUserAccountAsync(HttpClient client, DetailedUserDTO user, bool shouldSucceed = true)
+        {
+            var userToken = await GetToken(user.email, "ACTIVATE_ACCOUNT"); // Get  token from DB
+            var payload = new AccountActivationRequestDTO() {token = userToken.token};
+            
+            var (response, msg) =
+                await HttpRequest.SendAsync<AccountActivationRequestDTO, UserDTO>(client, HttpMethod.Post, 
+                    "/v1/users/confirm-registration", payload);
+            
+            // Assert
+            if (shouldSucceed)
+            {
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+                var confirmedUser = await GetUserByEmail(user.email);
+                Assert.Equal(user.email, confirmedUser.email);
+                Assert.True(confirmedUser.activated);
+            }
+            else
+            {
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            }
+        }
+        
+        /// <summary>
+        /// Returns the details of the user with the specified email address.
+        /// </summary>
+        /// <param name="email">The email address of the user to be found</param>
+        /// <param name="shouldSucceed">Optional, whether the action should succeed</param>
+        /// <returns>Returns a UserObj object with the users account details.</returns>
+        private static async Task<UserObj> GetUserByEmail(string email, bool shouldSucceed = true)
+        {
+            var db = new DatabaseQuery();
+            const string checkForUserSQL = "SELECT * FROM user WHERE email = @Email";
+            
+            var checkForUserSQLParams = new DynamicParameters();
+            checkForUserSQLParams.Add("@Email", email);
+            if (shouldSucceed)
+                return await db.RunQuerySingleAsync<UserObj>(checkForUserSQL, checkForUserSQLParams); // Get user from DB
+            
+            var users = await db.RunQueryAsync<UserObj>(checkForUserSQL, checkForUserSQLParams); // Get user from DB
+            Assert.Empty(users);
+            return new UserObj();
+        }
+        
+        /// <summary>
+        /// Returns a single token associated with the user's email address. Don't use this if you
+        /// anticipate there will be more than one token
+        /// </summary>
+        /// <param name="email">Email address of the user whose tokens are being searched for.</param>
+        /// <param name="type">The type of token to be searching for</param>
+        /// <param name="shouldSucceed">Optional, whether the action should succeed</param>
+        /// <returns></returns>
+        private static async Task<Token> GetToken(string email, string type, bool shouldSucceed = true)
+        {
+            var db = new DatabaseQuery();
+            const string getNewUserTokenSQL = @"
+SELECT token, date_created, type 
+FROM user_email_token 
+  JOIN user USING(user_id) 
+WHERE email = @Email AND type = @Type";
+            
+            var checkForUserSQLParams = new DynamicParameters();
+            checkForUserSQLParams.Add("@Email", email);
+            checkForUserSQLParams.Add("@Type", type);
+            
+            // Get tokens from DB
+            var tokens = (await db.RunQueryAsync<Token>(getNewUserTokenSQL, checkForUserSQLParams)).ToList(); 
+
+            if (shouldSucceed)
+            {
+                Assert.NotEmpty(tokens);
+                return tokens.First();
+            }
+            
+            Assert.Empty(tokens);
+            return new Token();
+        }
+        
+        private class UserObj
+        {
+            public string email { get; set; }
+            public string password { get; set; }
+            public string forename { get; set; }
+            public string surname { get; set; }
+            public string organization { get; set; }
+            public bool activated { get; set; }
+            public uint user_id { get; set; }
+        }
+        
+        private class Token
+        {
+            public string token { get; set; }
+            public string type { get; set; }
+            public DateTime date_created { get; set; }
+        }
+    }
+}

--- a/api-test/TextTest.cs
+++ b/api-test/TextTest.cs
@@ -499,7 +499,7 @@ namespace SQE.ApiTest
             Assert.NotEmpty(msg.editors);
             Assert.NotEqual((uint)0, msg.lineId);
             Assert.NotEmpty(msg.signs);
-            Assert.NotEqual((uint)0, msg.signs.First().nextSignInterpretations.First().nextSignInterpretationId);
+            Assert.NotEqual((uint)0, msg.signs.First().signInterpretations.First().nextSignInterpretations.First().nextSignInterpretationId);
             Assert.NotEmpty(msg.signs.First().signInterpretations);
             Assert.NotEqual((uint)0, msg.signs.First().signInterpretations.First().signInterpretationId);
             Assert.NotEmpty(msg.signs.First().signInterpretations.First().attributes);
@@ -508,12 +508,6 @@ namespace SQE.ApiTest
             var editorIds = new List<uint> {msg.editorId};
             foreach (var sign in msg.signs)
             {
-                foreach (var nexSign in sign.nextSignInterpretations)
-                {
-                    if (!msg.editors.ContainsKey(nexSign.editorId))
-                        editorIds.Add(nexSign.editorId);
-                }
-
                 foreach (var signInterpretation in sign.signInterpretations)
                 {
                     foreach (var attr in signInterpretation.attributes)
@@ -526,6 +520,12 @@ namespace SQE.ApiTest
                     {
                         if (!msg.editors.ContainsKey(roi.editorId))
                             editorIds.Add(roi.editorId);
+                    }
+                    
+                    foreach (var nexSign in signInterpretation.nextSignInterpretations)
+                    {
+                        if (!msg.editors.ContainsKey(nexSign.editorId))
+                            editorIds.Add(nexSign.editorId);
                     }
                 }
             }
@@ -547,7 +547,7 @@ namespace SQE.ApiTest
             Assert.NotEmpty(msg.textFragments.First().lines);
             Assert.NotEqual((uint)0, msg.textFragments.First().lines.First().lineId);
             Assert.NotEmpty(msg.textFragments.First().lines.First().signs);
-            Assert.NotEqual((uint)0, msg.textFragments.First().lines.First().signs.First().nextSignInterpretations.First().nextSignInterpretationId);
+            Assert.NotEqual((uint)0, msg.textFragments.First().lines.First().signs.First().signInterpretations.First().nextSignInterpretations.First().nextSignInterpretationId);
             Assert.NotEmpty(msg.textFragments.First().lines.First().signs.First().signInterpretations);
             Assert.NotEqual((uint)0, msg.textFragments.First().lines.First().signs.First().signInterpretations.First().signInterpretationId);
             Assert.NotEmpty(msg.textFragments.First().lines.First().signs.First().signInterpretations.First().attributes);
@@ -566,12 +566,6 @@ namespace SQE.ApiTest
                     
                     foreach (var sign in line.signs)
                     {
-                        foreach (var nexSign in sign.nextSignInterpretations)
-                        {
-                            if (!msg.editors.ContainsKey(nexSign.editorId))
-                                editorIds.Add(nexSign.editorId);
-                        }
-
                         foreach (var signInterpretation in sign.signInterpretations)
                         {
                             foreach (var attr in signInterpretation.attributes)
@@ -584,6 +578,12 @@ namespace SQE.ApiTest
                             {
                                 if (!msg.editors.ContainsKey(roi.editorId))
                                     editorIds.Add(roi.editorId);
+                            }
+                            
+                            foreach (var nexSign in signInterpretation.nextSignInterpretations)
+                            {
+                                if (!msg.editors.ContainsKey(nexSign.editorId))
+                                    editorIds.Add(nexSign.editorId);
                             }
                         }
                     }

--- a/api-test/TextTest.cs
+++ b/api-test/TextTest.cs
@@ -144,6 +144,8 @@ namespace SQE.ApiTest
                 {
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
+
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -178,6 +180,8 @@ namespace SQE.ApiTest
                         i > 0 ? i + 1 : i // skip index 1, which is the new text fragment
                         ]);
                 }
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -212,6 +216,8 @@ namespace SQE.ApiTest
                         i > updatedTextFragments.textFragments.Count - 3 ? i + 1 : i // skip the second to last, which is the new text fragment
                         ]);
                 }
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -253,6 +259,8 @@ namespace SQE.ApiTest
                         i > 0 ? i + 1 : i // skip index 1, which is the new text fragment
                     ]);
                 }
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
 
             #endregion should succeed
@@ -271,6 +279,8 @@ namespace SQE.ApiTest
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -297,6 +307,8 @@ namespace SQE.ApiTest
                 {
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -323,6 +335,8 @@ namespace SQE.ApiTest
                 {
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -355,6 +369,8 @@ namespace SQE.ApiTest
                 {
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -392,6 +408,8 @@ namespace SQE.ApiTest
                 Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
                 var secondUpdateTextFragments = await _getEditionTextFragments(editionId, await HttpRequest.GetJWTAsync(_client)); // Get the updated list of text fragments in the edition
                 updatedTextFragments.textFragments.ShouldDeepEqual(secondUpdateTextFragments.textFragments);
+                
+                await HttpRequest.DeleteEdition(_client, editionId, true);
             }
             
             #endregion should fail

--- a/api-test/TextTest.cs
+++ b/api-test/TextTest.cs
@@ -145,7 +145,7 @@ namespace SQE.ApiTest
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -181,7 +181,7 @@ namespace SQE.ApiTest
                         ]);
                 }
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -217,7 +217,7 @@ namespace SQE.ApiTest
                         ]);
                 }
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -260,7 +260,7 @@ namespace SQE.ApiTest
                     ]);
                 }
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
 
             #endregion should succeed
@@ -280,7 +280,7 @@ namespace SQE.ApiTest
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -308,7 +308,7 @@ namespace SQE.ApiTest
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -336,7 +336,7 @@ namespace SQE.ApiTest
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -370,7 +370,7 @@ namespace SQE.ApiTest
                     textFragments.textFragments[i].ShouldDeepEqual(updatedTextFragments.textFragments[i]);
                 }
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             [Fact]
@@ -409,7 +409,7 @@ namespace SQE.ApiTest
                 var secondUpdateTextFragments = await _getEditionTextFragments(editionId, await HttpRequest.GetJWTAsync(_client)); // Get the updated list of text fragments in the edition
                 updatedTextFragments.textFragments.ShouldDeepEqual(secondUpdateTextFragments.textFragments);
                 
-                await HttpRequest.DeleteEdition(_client, editionId, true);
+                await EditionHelpers.DeleteEdition(_client, editionId, true);
             }
             
             #endregion should fail
@@ -448,7 +448,7 @@ namespace SQE.ApiTest
         private async Task<uint> _getClonedEdition()
         {
             var (editionId, _) = await _getTextRandomFragment(); // Get an edition with text fragments
-            return await HttpRequest.CreateNewEdition(_client, editionId); // Clone it
+            return await EditionHelpers.CreateCopyOfEdition(_client, editionId); // Clone it
         }
 
         private async Task<TextFragmentDataListDTO> _getEditionTextFragments(uint editionId, string jwt = null)

--- a/data-access/ArtefactRepository.cs
+++ b/data-access/ArtefactRepository.cs
@@ -227,10 +227,7 @@ namespace SQE.SqeHttpApi.DataAccess
             var res = string.Join("", binaryMask);
             var Mask = Geometry.Deserialize<WkbSerializer>(binaryMask).SerializeString<WktSerializer>();*/
            
-            using (var transactionScope = new TransactionScope(
-                TransactionScopeOption.Required,
-                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted })
-            )
+            using (var transactionScope = new TransactionScope())
             {
                 using (var connection = OpenConnection())
                 {

--- a/data-access/ArtefactRepository.cs
+++ b/data-access/ArtefactRepository.cs
@@ -229,12 +229,13 @@ namespace SQE.SqeHttpApi.DataAccess
            
             using (var transactionScope = new TransactionScope(
                 TransactionScopeOption.Required,
-                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted }))
+                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted })
+            )
             {
                 using (var connection = OpenConnection())
                 {
                     // Create a new edition
-                    await connection.ExecuteAsync("INSERT INTO artefact () VALUES()");
+                    await connection.ExecuteAsync("INSERT INTO artefact (artefact_id) VALUES(NULL)");
                         
                     var artefactId = await connection.QuerySingleAsync<uint>(LastInsertId.GetQuery);
                     if (artefactId == 0)
@@ -252,7 +253,6 @@ namespace SQE.SqeHttpApi.DataAccess
                     await newName;
                     //Cleanup
                     transactionScope.Complete();
-                    connection.Close();
                         
                     return artefactId;
                 }

--- a/data-access/DbConnectionBase.cs
+++ b/data-access/DbConnectionBase.cs
@@ -1,6 +1,12 @@
-﻿using MySql.Data.MySqlClient;
+﻿using System;
+using System.Collections.Generic;
+using MySql.Data.MySqlClient;
 using Microsoft.Extensions.Configuration;
 using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Polly;
 
 
 namespace SQE.SqeHttpApi.DataAccess
@@ -8,10 +14,12 @@ namespace SQE.SqeHttpApi.DataAccess
     public class DbConnectionBase
     {
         private readonly IConfiguration _config;
+        private readonly DatabaseCommunicationRetryPolicy _retryPolicy;
 
         protected DbConnectionBase(IConfiguration config)
         {
             _config = config;
+            _retryPolicy = new DatabaseCommunicationRetryPolicy();
         }
 
         private string ConnectionString
@@ -27,9 +35,365 @@ namespace SQE.SqeHttpApi.DataAccess
             }
         }
 
-        protected IDbConnection OpenConnection()
+        // This returns the ReliableMySqlConnection, which wraps MySqlConnection in a set of retry policies for handling
+        // the transient database errors where MariaDB says the transaction should be retried.
+        protected IDbConnection OpenConnection() => new ReliableMySqlConnection(ConnectionString, _retryPolicy);
+    }
+    
+    // I used a lot of help from https://sergeyakopov.com/reliable-database-connections-and-commands-with-polly/
+    // to implement this Polly retry and circuit breaker system.
+    public interface IRetryPolicy
+    {
+        void ExecuteRetry(Action operation);
+
+        TResult ExecuteRetry<TResult>(Func<TResult> operation);
+
+        Task ExecuteRetry(Func<Task> operation, CancellationToken cancellationToken);
+
+        Task<TResult> ExecuteRetry<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken);
+        void ExecuteRetryWithCircuitBreaker(Action operation);
+
+        TResult ExecuteRetryWithCircuitBreaker<TResult>(Func<TResult> operation);
+
+        Task ExecuteRetryWithCircuitBreaker(Func<Task> operation, CancellationToken cancellationToken);
+
+        Task<TResult> ExecuteRetryWithCircuitBreaker<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken);
+    }
+    
+    /// <summary>
+    /// These are the policies for retrying db executions on transient errors from database interactions and for
+    /// pausing all attempts to get a connection when none are available from the database.
+    /// 
+    /// We only retry on the truly transient errors that explicitly suggest we should retry:
+    /// 1205	HY000	ER_LOCK_WAIT_TIMEOUT	Lock wait timeout exceeded; try restarting transaction
+    /// 1213	40001	ER_LOCK_DEADLOCK	Deadlock found when trying to get lock; try restarting transaction
+    /// 1412	HY000	ER_TABLE_DEF_CHANGED	Table definition has changed, please retry transaction
+    ///
+    /// In the case of errors 1203 (above max_user_connections) and 1040 (too many connections) we should short circuit
+    /// all db interactions for a little while to see if the db will recover on its own.
+    /// 
+    /// TODO: Could we do anything useful for error 1927? Research and see if it should just be retried.
+    /// </summary>
+    public class DatabaseCommunicationRetryPolicy : IRetryPolicy
+    {
+        private const int RetryCount = 5;
+        private const int WaitBetweenRetriesInMilliseconds = 200;
+        private readonly Random _random = new Random();
+
+        private readonly List<int> _retrySqlExceptions = new List<int>{ 1205, 1213, 1412 };
+        private readonly List<int> _pauseExceptions = new List<int>{ 1040, 1203 };
+
+        private readonly AsyncPolicy _retryPolicyAsync;
+        private readonly AsyncPolicy _circuitBreakPolicyAsync;
+        private readonly Policy _retryPolicy;
+        private readonly Policy _circuitBreakPolicy;
+
+        /// <summary>
+        /// In both sync and async the command will be retried a maximum of 5 times when the exception MariaDb errors
+        /// 1205, 1213, 1412, or 1622 are received (all other exceptions bubble up immediately). After max-retries the
+        /// exception is allowed to bubble up.
+        /// This also contains a circuit breaker, so that whenever
+        /// </summary>
+        public DatabaseCommunicationRetryPolicy()
         {
-            return new MySqlConnection(ConnectionString);
+            _retryPolicyAsync = Policy
+                .Handle<MySqlException>(exception => _retrySqlExceptions.Contains(exception.Number))
+                .WaitAndRetryAsync(
+                    retryCount: RetryCount,
+                    sleepDurationProvider: attempt => TimeSpan.FromMilliseconds(_waitTime(attempt))
+                );
+            
+            _retryPolicy = Policy
+                .Handle<MySqlException>(exception => _retrySqlExceptions.Contains(exception.Number))
+                .WaitAndRetry(
+                    retryCount: RetryCount,
+                    sleepDurationProvider: attempt => TimeSpan.FromMilliseconds(_waitTime(attempt))
+                );
+
+            _circuitBreakPolicyAsync = Policy
+                .Handle<MySqlException>(exception => _pauseExceptions.Contains(exception.Number))
+                .CircuitBreakerAsync(
+                    exceptionsAllowedBeforeBreaking: RetryCount, 
+                    durationOfBreak: TimeSpan.FromMinutes(1)
+                );
+            
+            _circuitBreakPolicy = Policy
+                .Handle<MySqlException>(exception => _pauseExceptions.Contains(exception.Number))
+                .CircuitBreaker(
+                    exceptionsAllowedBeforeBreaking: RetryCount, 
+                    durationOfBreak: TimeSpan.FromMinutes(1)
+                );
+        }
+
+        /// <summary>
+        /// Each retry waits a bit longer (retryCount * WaitBetweenRetriesInMilliseconds), and a small amount of randomness
+        /// is added to that wait time (somewhere between -100 and 100ms) so that competing commands (deadlock) are less
+        /// likely to keep colliding with each other.
+        /// </summary>
+        /// <param name="retryCount">The current count of retries</param>
+        /// <returns></returns>
+        private int _waitTime(int retryCount) =>
+            (retryCount * WaitBetweenRetriesInMilliseconds) + _random.Next(-100, 100);
+
+        public void ExecuteRetry(Action operation)
+        {
+            _retryPolicy.Execute(operation.Invoke);
+        }
+
+        public TResult ExecuteRetry<TResult>(Func<TResult> operation)
+        {
+            return _retryPolicy.Execute(() => operation.Invoke());
+        }
+
+        public async Task ExecuteRetry(Func<Task> operation, CancellationToken cancellationToken)
+        {
+            await _retryPolicyAsync.ExecuteAsync(operation.Invoke);
+        }
+
+        public async Task<TResult> ExecuteRetry<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken)
+        {
+            return await _retryPolicyAsync.ExecuteAsync(operation.Invoke);
+        }
+        
+        public void ExecuteRetryWithCircuitBreaker(Action operation)
+        {
+            _retryPolicy.Wrap(_circuitBreakPolicy).Execute(operation.Invoke);
+        }
+
+        public TResult ExecuteRetryWithCircuitBreaker<TResult>(Func<TResult> operation)
+        {
+            return _retryPolicy.Wrap(_circuitBreakPolicy).Execute(operation.Invoke);
+        }
+
+        public async Task ExecuteRetryWithCircuitBreaker(Func<Task> operation, CancellationToken cancellationToken)
+        {
+            await _retryPolicyAsync.WrapAsync(_circuitBreakPolicyAsync).ExecuteAsync(operation.Invoke);
+        }
+
+        public async Task<TResult> ExecuteRetryWithCircuitBreaker<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken)
+        {
+            return await _retryPolicyAsync.WrapAsync(_circuitBreakPolicyAsync).ExecuteAsync(operation.Invoke);
+        }
+    }
+
+    /// <summary>
+    /// This wraps the DbConnection provided by MySqlConnection and adds the retry policies of
+    /// DatabaseCommunicationRetryPolicy to the Open() method in order to deal with transient errors that
+    /// prevent betting a database connection. It also overrides the CreateDbCommand to make it use
+    /// ReliableMySqlDbCommand, which is a wrapper for the DbCommand implementation of MySqlCommand that
+    /// also wraps those interactions in the retry policy.
+    /// </summary>
+    public class ReliableMySqlConnection : DbConnection
+    {
+        private readonly MySqlConnection _underlyingConnection;
+        private readonly DatabaseCommunicationRetryPolicy _retryPolicy;
+
+        private string _connectionString;
+
+        public ReliableMySqlConnection(DatabaseCommunicationRetryPolicy retryPolicy)
+        {
+            _retryPolicy = retryPolicy;
+            _underlyingConnection = new MySqlConnection(ConnectionString);
+        }
+        
+        public ReliableMySqlConnection(string connectionString, DatabaseCommunicationRetryPolicy retryPolicy) : this(retryPolicy)
+        {
+            ConnectionString = connectionString;
+        }
+
+        // Set the _connectionString for this class and the ConnectionString of the underlying MySqlConnection.
+        public sealed override string ConnectionString
+        {
+            get => _connectionString;
+
+            set
+            {
+                _connectionString = value;
+                _underlyingConnection.ConnectionString = value;
+            }
+        }
+
+        public override int ConnectionTimeout => _underlyingConnection.ConnectionTimeout;
+
+        public override string Database => _underlyingConnection.Database;
+
+        public override string DataSource => _underlyingConnection.DataSource;
+
+        public override string ServerVersion => _underlyingConnection.ServerVersion;
+
+        public override ConnectionState State => _underlyingConnection.State;
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            return _underlyingConnection.BeginTransaction(isolationLevel);
+        }
+        
+        public override void ChangeDatabase(string databaseName)
+        {
+            _underlyingConnection.ChangeDatabase(databaseName);
+        }
+
+        public override void Close() => _underlyingConnection.Close();
+        
+        // Force usage of the ReliableMySqlDbCommand implementation of DbCommand
+        protected override DbCommand CreateDbCommand()
+        {
+            return new ReliableMySqlDbCommand(_underlyingConnection.CreateCommand(), _retryPolicy);
+        }
+        
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_underlyingConnection.State == ConnectionState.Open)
+                {
+                    _underlyingConnection.Close();
+                }
+
+                _underlyingConnection.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        // Wrap the MySqlConnection Open() method in the retry policy with circuit breaker.
+        public override void Open()
+        {
+            _retryPolicy.ExecuteRetryWithCircuitBreaker(() =>  _underlyingConnection.Open());
+        }
+    }
+    
+    /// <summary>
+    /// This provides a wrapper for the MySqlCommand implementation of DbCommand in order to wrap some methods
+    /// in the retry policy.
+    /// </summary>
+    public class ReliableMySqlDbCommand : DbCommand
+    {
+        private readonly MySqlCommand _underlyingSqlCommand;
+        private readonly IRetryPolicy _retryPolicy;
+
+        public ReliableMySqlDbCommand(IRetryPolicy retryPolicy)
+        {
+            _retryPolicy = retryPolicy;
+        }
+        
+        public ReliableMySqlDbCommand(MySqlCommand command, IRetryPolicy retryPolicy) : this(retryPolicy)
+        {
+            _underlyingSqlCommand = command;
+        }
+        
+        public ReliableMySqlDbCommand(MySqlCommand command, DbConnection connection, 
+            IRetryPolicy retryPolicy) : this(command, retryPolicy)
+        {
+            DbConnection = connection;
+        }
+        
+        public ReliableMySqlDbCommand(MySqlCommand command, DbConnection connection, DbTransaction transaction,
+            IRetryPolicy retryPolicy) : this(command, connection, retryPolicy)
+        {
+            DbTransaction = transaction;
+        }
+
+        public override string CommandText
+        {
+            get => _underlyingSqlCommand.CommandText;
+            set => _underlyingSqlCommand.CommandText = value;
+        }
+
+        public override int CommandTimeout
+        {
+            get => _underlyingSqlCommand.CommandTimeout;
+            set => _underlyingSqlCommand.CommandTimeout = value;
+        }
+
+        public override CommandType CommandType
+        {
+            get => _underlyingSqlCommand.CommandType;
+            set => _underlyingSqlCommand.CommandType = value;
+        }
+
+        protected override DbConnection DbConnection
+        {
+            get => _underlyingSqlCommand.Connection;
+            set => _underlyingSqlCommand.Connection = (MySqlConnection)value; // Cast to a MySqlConnection for safety
+        }
+
+        protected override DbParameterCollection DbParameterCollection => _underlyingSqlCommand.Parameters;
+
+        protected override DbTransaction DbTransaction
+        {
+            get => _underlyingSqlCommand.Transaction;
+            set => _underlyingSqlCommand.Transaction = (MySqlTransaction)value; // Cast to a MySqlTransaction for safety
+        }
+
+        public override bool DesignTimeVisible
+        {
+            get => _underlyingSqlCommand.DesignTimeVisible;
+            set => _underlyingSqlCommand.DesignTimeVisible = value;
+        }
+
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get => _underlyingSqlCommand.UpdatedRowSource;
+            set => _underlyingSqlCommand.UpdatedRowSource = value;
+        }
+
+        public override void Cancel()
+        {
+            _underlyingSqlCommand.Cancel();
+        }
+        
+        protected override DbParameter CreateDbParameter() => _underlyingSqlCommand.CreateParameter();
+        
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _underlyingSqlCommand.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        // Wrap ExecuteReader in the retry policy.
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            return _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.ExecuteReader(behavior));
+        }
+
+        // Wrap ExecuteReaderAsync in the retry policy.
+        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken token)
+        {
+            return _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.ExecuteReaderAsync(behavior, token));
+        }
+
+        // Wrap ExecuteNonQuery in the retry policy.
+        public override int ExecuteNonQuery()
+        {
+            return _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.ExecuteNonQuery());
+        }
+        
+        // Wrap ExecuteNonQueryAsync in the retry policy.
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken token)
+        {
+            return _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.ExecuteNonQueryAsync(token));
+        }
+
+        // Wrap ExecuteScalar in the retry policy.
+        public override object ExecuteScalar()
+        {
+            return _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.ExecuteScalar());
+        }
+        
+        // Wrap ExecuteScalarAsync in the retry policy.
+        public override Task<object> ExecuteScalarAsync(CancellationToken token)
+        {
+            return _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.ExecuteScalarAsync(token));
+        }
+
+        public override void Prepare()
+        {
+            _retryPolicy.ExecuteRetry(() => _underlyingSqlCommand.Prepare());
         }
     }
 }

--- a/data-access/EditionRepository.cs
+++ b/data-access/EditionRepository.cs
@@ -157,7 +157,10 @@ namespace SQE.SqeHttpApi.DataAccess
             // until the copy process was complete in order to guard against
             // creating an inconsistent copy.
             // What if someone unlocks the source scroll mid-copy?
-            using (var transactionScope = new TransactionScope())
+            using (var transactionScope = new TransactionScope(
+                TransactionScopeOption.Required,
+                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted })
+            )
             {
                 using (var connection = OpenConnection())
                 {

--- a/data-access/EditionRepository.cs
+++ b/data-access/EditionRepository.cs
@@ -269,7 +269,7 @@ namespace SQE.SqeHttpApi.DataAccess
             {
                 // Verify that the token is still valid
                 var deleteToken = await connection.ExecuteAsync(DeleteUserEmailTokenQuery.GetTokenQuery, new
-                    { Token = token, Type = CreateUserEmailTokenQuery.DeleteEdition});
+                    { Tokens = new []{token}, Type = CreateUserEmailTokenQuery.DeleteEdition});
                 if (deleteToken != 1)
                     throw new StandardErrors.DataNotWritten("verifying the delete request token");
                 

--- a/data-access/EditionRepository.cs
+++ b/data-access/EditionRepository.cs
@@ -264,11 +264,11 @@ namespace SQE.SqeHttpApi.DataAccess
                 return await GetDeleteToken(user);
             }
 
-            // Remove read/write permissions from all editors, so they cannot make any changes while the delete proceeds
+            // Remove write permissions from all editors, so they cannot make any changes while the delete proceeds
             var editors = await _getEditionEditors(user.editionId.Value);
             await Task.WhenAll(
                 editors.Select(
-                    x => ChangeEditionEditorRights(user, x.Email, false, false, x.MayLock, x.IsAdmin)
+                    x => ChangeEditionEditorRights(user, x.Email, x.MayRead, false, x.MayLock, x.IsAdmin)
                     )
                 );
 

--- a/data-access/EditionRepository.cs
+++ b/data-access/EditionRepository.cs
@@ -264,7 +264,10 @@ namespace SQE.SqeHttpApi.DataAccess
                 return await GetDeleteToken(user);
             }
 
-            using (var transactionScope = new TransactionScope())
+            using (var transactionScope = new TransactionScope(
+                TransactionScopeOption.Required,
+                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted })
+            ) // This transaction may take a while, so we cannot lock all of these tables. Otherwise, we DO get deadlock.
             using (var connection = OpenConnection())
             {
                 // Verify that the token is still valid

--- a/data-access/EditionRepository.cs
+++ b/data-access/EditionRepository.cs
@@ -76,9 +76,9 @@ namespace SQE.SqeHttpApi.DataAccess
             {
                 model.Permission = new Permission
                 {
-                    IsAdmin = model.Owner.UserId == currentUserId.Value && result.Admin,
-                    MayWrite = model.Owner.UserId == currentUserId.Value && result.MayWrite,
-                    MayLock = model.Owner.UserId == currentUserId.Value && result.MayLock,
+                    IsAdmin = result.Admin,
+                    MayWrite = result.MayWrite,
+                    MayLock = result.MayLock,
                 };
             }
             else

--- a/data-access/Helpers/DatabaseWriter.cs
+++ b/data-access/Helpers/DatabaseWriter.cs
@@ -153,11 +153,7 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
             // Grab a transaction scope, we roll back all changes if any transactions fail
             // I could limit the transaction scope to each individual mutation request,
             // but I fear the multiple requests may be dependent upon each other (i.e., all or nothing).
-            using (var transactionScope = new TransactionScope(
-                TransactionScopeOption.Required,
-                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted }
-                )
-            )
+            using (var transactionScope = new TransactionScope())
             using (var connection = OpenConnection())
             {
                 foreach (var mutationRequest in mutationRequests)

--- a/data-access/Helpers/DatabaseWriter.cs
+++ b/data-access/Helpers/DatabaseWriter.cs
@@ -39,13 +39,13 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Initializes a new instance of the <see cref="T:SQE.SqeHttpApi.DataAccess.Helpers.MutationRequest"/> class.
         /// </summary>
-        /// <param Name="action">Set the mutate to Create, Update, or Delete.
+        /// <param name="action">Set the mutate to Create, Update, or Delete.
         /// For Update or Delete, the id for the record being updated or deleted must be passed in tablePkId.</param>
-        /// <param Name="parameters">These are the parameters for the columns that will be inserted/updated in the SQL query.
+        /// <param name="parameters">These are the parameters for the columns that will be inserted/updated in the SQL query.
         /// The parameter names must start with @ and use the column Name exactly as it is written in the database (e.g., `@scroll_id`).
         /// For Delete actions this should be empty.</param>
-        /// <param Name="tableName">Name of the table you are altering.</param>
-        /// <param Name="tablePkId">Id of the record being updated or deleted.  This will be null with an Insert action.</param>
+        /// <param name="tableName">Name of the table you are altering.</param>
+        /// <param name="tablePkId">Id of the record being updated or deleted.  This will be null with an Insert action.</param>
         public MutationRequest(MutateType action, DynamicParameters parameters, string tableName, uint? tablePkId = null)
         {
             Action = action;
@@ -101,9 +101,9 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Initializes a new instance of the <see cref="T:SQE.SqeHttpApi.DataAccess.Helpers.AlteredRecord"/> class.
         /// </summary>
-        /// <param Name="tableName">Name of the table that was altered.</param>
-        /// <param Name="oldId">Id of the record that was altered. Only present with update/delete.</param>
-        /// <param Name="newId">Id of the new record that was created. Only present with update/create.</param>
+        /// <param name="tableName">Name of the table that was altered.</param>
+        /// <param name="oldId">Id of the record that was altered. Only present with update/delete.</param>
+        /// <param name="newId">Id of the new record that was created. Only present with update/create.</param>
         public AlteredRecord(string tableName, uint? oldId, uint? newId)
         {
             TableName = tableName;
@@ -136,11 +136,15 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// </summary>
         /// <returns>A list of AlteredRecord objects containing the details of each mutation.
         /// The order of the returned list or results matches the order of the list of mutation requests</returns>
-        /// <param Name="user"></param>
-        /// <param Name="mutationRequests">List of mutation requests.</param>
+        /// <param name="user"></param>
+        /// <param name="mutationRequests">List of mutation requests.</param>
         public async Task<List<AlteredRecord>> WriteToDatabaseAsync(UserInfo user,
             List<MutationRequest> mutationRequests)
         {
+            // Check the permissions and throw if user has no rights to alter this edition
+            if (!(await user.MayWrite()) && !(await user.EditionEditorId()).HasValue)
+                throw new StandardErrors.NoWritePermissions(user);
+            
             var alteredRecords = new List<AlteredRecord>();
             // Grab a transaction scope, we roll back all changes if any transactions fail
             // I could limit the transaction scope to each individual mutation request,
@@ -152,9 +156,6 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
             )
             using (var connection = OpenConnection())
             {
-                // Check the permissions and throw if user has no rights to alter this scrollVersion
-                if (!(await user.MayWrite()) && !(await user.EditionEditorId()).HasValue)
-                    throw new StandardErrors.NoWritePermissions(user);
                 foreach (var mutationRequest in mutationRequests)
                 {
                     // Set the editionId for the mutation.
@@ -202,8 +203,8 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// Insert record into table.  This takes care of writing the new record (if necessary) and makes the necessary
         /// changes to the owner tables.  It also records the action in the database.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction.</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction.</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
         /// <returns>The alteredRecord object to be added to the request response.</returns>
         private static async Task<AlteredRecord> InsertAsync(IDbConnection connection, MutationRequest mutationRequest)
         {
@@ -224,8 +225,8 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// Delete record.  This takes care of deleting the record and by making the necessary
         /// changes to the owner table.  It also records the action in the database.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
         /// <returns>The alteredRecord object to be added to the request response.</returns>
         private static async Task<AlteredRecord> DeleteAsync(IDbConnection connection, MutationRequest mutationRequest)
         {
@@ -243,8 +244,8 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// This inserts the requested data into its table. If a record with the same data already exists, then the
         /// Id of that record is used in place of creating a duplicate record.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
         /// <returns>Returns the Id of the newly inserted record. If a record with the same data already existed,
         /// then the Id of that record is returned.</returns>
         private static async Task<uint> InsertOwnedTableAsync(IDbConnection connection, MutationRequest mutationRequest)
@@ -295,9 +296,9 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Creates an entry in the owner table linking the editionId to the record with the inserted data.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
-        /// <param Name="insertId">The primary key Id of the record that was just inserted.</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="insertId">The primary key Id of the record that was just inserted.</param>
         /// <returns></returns>
         private static async Task InsertOwnerTableAsync(IDbConnection connection, MutationRequest mutationRequest,  uint insertId)
         {
@@ -316,8 +317,8 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Delete the entry in the owner table that links a particular record to a specific editionId
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
         /// <returns></returns>
         private static async Task DeleteOwnerTableAsync(IDbConnection connection, MutationRequest mutationRequest)
         {
@@ -337,7 +338,7 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Convenience function to get the last insert Id. Throws on error.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
         /// <returns>Returns the Id of the last inserted record.</returns>
         private static async Task<uint> LastInsertIdAsync(IDbConnection connection)
         {
@@ -348,8 +349,8 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Creates an entry in the main_action table for the current mutation request.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
         /// <returns></returns>
         private static async Task AddMainActionAsync(IDbConnection connection, MutationRequest mutationRequest)
         {
@@ -367,9 +368,9 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Creates and entry in the single_action table to record the mutation.
         /// </summary>
-        /// <param Name="connection">An IDbConnection belonging to the current transaction</param>
-        /// <param Name="mutationRequest">A mutation request object with all the necessary data.</param>
-        /// <param Name="action"></param>
+        /// <param name="connection">An IDbConnection belonging to the current transaction</param>
+        /// <param name="mutationRequest">A mutation request object with all the necessary data.</param>
+        /// <param name="action"></param>
         /// <returns></returns>
         private static async Task AddSingleActionAsync(IDbConnection connection, MutationRequest mutationRequest, SingleAction action)
         {

--- a/data-access/Helpers/DatabaseWriter.cs
+++ b/data-access/Helpers/DatabaseWriter.cs
@@ -141,6 +141,10 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         public async Task<List<AlteredRecord>> WriteToDatabaseAsync(UserInfo user,
             List<MutationRequest> mutationRequests)
         {
+            // Check if the edition is locked
+            if ((await user.EditionLocked()))
+                throw new StandardErrors.LockedData(user);
+            
             // Check the permissions and throw if user has no rights to alter this edition
             if (!(await user.MayWrite()) && !(await user.EditionEditorId()).HasValue)
                 throw new StandardErrors.NoWritePermissions(user);

--- a/data-access/Helpers/DatabaseWriter.cs
+++ b/data-access/Helpers/DatabaseWriter.cs
@@ -123,7 +123,7 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <summary>
         /// Enum for allowed actions in the single_action database table.
         /// </summary>
-        public enum SingleAction
+        private enum SingleAction
         {
             Add,
             Delete

--- a/data-access/Helpers/DatabaseWriter.cs
+++ b/data-access/Helpers/DatabaseWriter.cs
@@ -139,6 +139,13 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
         /// <param name="user"></param>
         /// <param name="mutationRequests">List of mutation requests.</param>
         public async Task<List<AlteredRecord>> WriteToDatabaseAsync(UserInfo user,
+        List<MutationRequest> mutationRequests)
+        {
+            return await DatabaseCommunicationRetryPolicy.ExecuteRetry(
+                () => _writeToDatabaseAsync(user, mutationRequests));
+        }
+
+        private async Task<List<AlteredRecord>> _writeToDatabaseAsync(UserInfo user,
             List<MutationRequest> mutationRequests)
         {
             // Check if the edition is locked

--- a/data-access/Helpers/Exceptions.cs
+++ b/data-access/Helpers/Exceptions.cs
@@ -212,6 +212,15 @@ namespace SQE.SqeHttpApi.DataAccess.Helpers
             }
         }
         
+        public class InputDataRuleViolation : BadInputException
+        {
+            private const string customMsg = "The request is not allowed because it violates the rule: $Rule.";
+            public InputDataRuleViolation(string rule)
+            {
+                this.Error = customMsg.Replace("$Rule", rule);
+            }
+        }
+        
         public class ConflictingData : ConflictingInputException
         {
             private const string customMsg = "The submitted $DataType conflicts with data already existing in the system.";

--- a/data-access/Models/EditionModels.cs
+++ b/data-access/Models/EditionModels.cs
@@ -24,9 +24,15 @@ namespace SQE.SqeHttpApi.DataAccess.Models
 
     public class Permission
     {
-        public bool CanWrite { get; set; }
-        public bool CanLock { get; set; }
-        public bool CanAdmin { get; set; }
+        public bool MayRead { get; set; }
+        public bool MayWrite { get; set; }
+        public bool MayLock { get; set; }
+        public bool IsAdmin { get; set; }
+    }
+
+    public class DetailedPermissions : Permission
+    {
+        public string Email { get; set; }
     }
 
     public class Share

--- a/data-access/Models/InterpretationAttribute.cs
+++ b/data-access/Models/InterpretationAttribute.cs
@@ -3,6 +3,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
     public class CharAttribute
     {
         public uint interpretationAttributeId { get; set; }
+        public byte sequence { get; set; }
         public uint attributeValueId { get; set; }
         public uint signInterpretationAttributeAuthor { get; set; }
         public float value { get; set; }

--- a/data-access/Models/Sign.cs
+++ b/data-access/Models/Sign.cs
@@ -5,7 +5,6 @@ namespace SQE.SqeHttpApi.DataAccess.Models
     public class Sign
     {
         public uint signId { get; set; }
-        public readonly HashSet<NextSignInterpretation> nextSignInterpretations = new HashSet<NextSignInterpretation>();
         public readonly List<SignInterpretation> signInterpretations = new List<SignInterpretation>();
     }
 }

--- a/data-access/Models/SignInterpretation.cs
+++ b/data-access/Models/SignInterpretation.cs
@@ -5,7 +5,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
     public class SignInterpretation
     {
         public uint signInterpretationId { get; set; }
-        public string signInterpretation { get; set; }
+        public string character { get; set; }
         public readonly List<CharAttribute> attributes = new List<CharAttribute>();
         public readonly List<SignInterpretationROI> signInterpretationRois = new List<SignInterpretationROI>();
     }

--- a/data-access/Models/SignInterpretation.cs
+++ b/data-access/Models/SignInterpretation.cs
@@ -8,6 +8,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
         public string character { get; set; }
         public readonly List<CharAttribute> attributes = new List<CharAttribute>();
         public readonly List<SignInterpretationROI> signInterpretationRois = new List<SignInterpretationROI>();
+        public readonly HashSet<NextSignInterpretation> nextSignInterpretations = new HashSet<NextSignInterpretation>();
     }
     
     public class NextSignInterpretation

--- a/data-access/Models/UserModels.cs
+++ b/data-access/Models/UserModels.cs
@@ -42,6 +42,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
         private readonly IUserRepository _userRepo;
         public uint? editionId;
         private uint? _editionEditorId;
+        private bool? _editionLocked;
         private bool? _mayWrite;
         private bool? _mayLock;
         private bool? _isAdmin;
@@ -51,6 +52,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
             this.editionId = editionId;
             this.userId = userId;
             _userRepo = userRepository;
+            _editionLocked = null;
             _mayWrite = null;
             _mayLock = null;
             _isAdmin = null;
@@ -77,6 +79,15 @@ namespace SQE.SqeHttpApi.DataAccess.Models
                 await SetPermissions();
             }
             return _editionEditorId.HasValue && _editionEditorId.Value == 0 ? null : _editionEditorId;
+        }
+        
+        public async Task<bool> EditionLocked()
+        {
+            if (!_editionLocked.HasValue)
+            {
+                await SetPermissions();
+            }
+            return _editionLocked ?? true;
         }
 
         public async Task<bool> MayWrite()
@@ -113,6 +124,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
             {
                 var permissions = await _userRepo.GetUserEditionPermissionsAsync(this);
                 _mayWrite = permissions.MayWrite && !permissions.Locked;
+                _editionLocked = permissions.Locked;
                 _mayLock = permissions.MayLock;
                 _isAdmin = permissions.IsAdmin;
                 _editionEditorId = permissions.EditionEditionEditorId;

--- a/data-access/Models/UserModels.cs
+++ b/data-access/Models/UserModels.cs
@@ -33,6 +33,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
         public bool MayLock { get; set; }
         public bool MayRead { get; set; }
         public bool IsAdmin { get; set; }
+        public bool Locked { get; set; }
     }
     
     public class UserInfo
@@ -59,7 +60,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
         /// Set the editionId of the user to a new editionID (the permissions are also
         /// retrieved for the new editionId).
         /// </summary>
-        /// <param Name="editionId"></param>
+        /// <param name="editionId">The desired editionId</param>
         public async void SetEditionId(uint editionId)
         {
             if (!this.editionId.HasValue || this.editionId.Value != editionId)
@@ -111,7 +112,7 @@ namespace SQE.SqeHttpApi.DataAccess.Models
             if (editionId.HasValue && userId.HasValue)
             {
                 var permissions = await _userRepo.GetUserEditionPermissionsAsync(this);
-                _mayWrite = permissions.MayWrite;
+                _mayWrite = permissions.MayWrite && !permissions.Locked;
                 _mayLock = permissions.MayLock;
                 _isAdmin = permissions.IsAdmin;
                 _editionEditorId = permissions.EditionEditionEditorId;

--- a/data-access/Queries/AuthorshipQueries.cs
+++ b/data-access/Queries/AuthorshipQueries.cs
@@ -13,7 +13,7 @@ FROM single_action
 JOIN main_action USING(main_action_id)
 JOIN scroll_version USING(scroll_version_id)
 JOIN user USING(user_id)
-WHERE single_action.table = ""@TableName"" AND single_action.action = ""add""
+WHERE single_action.table = @TableName AND single_action.action = 'add'
     AND (@IdList)
 GROUP BY single_action.id_in_table
     HAVING min(single_action.single_action_id)"; // Presumably a lower single_action_id is equivalent to an earlier date main_action. object this[int index]

--- a/data-access/Queries/AuthorshipQueries.cs
+++ b/data-access/Queries/AuthorshipQueries.cs
@@ -22,8 +22,8 @@ GROUP BY single_action.id_in_table
             /// This returns a query string that provides the original author for a list of
             /// Id's in a user editable table.
             /// </summary>
-            /// <param Name="tableName">The table containing the Id's being audited.</param>
-            /// <param Name="idList">The list of Id's to audit</param>
+            /// <param name="tableName">The table containing the Id's being audited.</param>
+            /// <param name="idList">The list of Id's to audit</param>
             /// <returns>A query string to be run with the database connector.</returns>
             public string GetQuery(string tableName, List<uint> idList)
             {

--- a/data-access/Queries/Edition.cs
+++ b/data-access/Queries/Edition.cs
@@ -185,4 +185,25 @@ SET copyright_holder = COALESCE(@CopyrightHolder, copyright_holder),
     collaborators = @Collaborators 
 WHERE edition_id = @EditionId";
     }
+
+    /// <summary>
+    /// Delete all entries for a specific edition from the specified table.
+    /// We ensure here that the user requesting this is indeed an admin (even though that should also have been
+    /// done in API logic elsewhere).
+    /// </summary>
+    internal static class DeleteEditionFromTable
+    {
+        private const string _sql = @"
+DELETE $Table
+FROM $Table
+JOIN edition_editor ON edition_editor.edition_id = @EditionId 
+  AND edition_editor.user_id = @UserId
+WHERE $Table.edition_id = @EditionId AND edition_editor.is_admin = 1
+";
+
+        public static string GetQuery(string table)
+        {
+            return _sql.Replace("$Table", table);
+        }
+    }
 }

--- a/data-access/Queries/MutateQueries.cs
+++ b/data-access/Queries/MutateQueries.cs
@@ -5,11 +5,12 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
     // Itay - Sure, let's add Query, it makes things clearer and maybe helps with possible collisions.
     
     // No more ON DUPLICATE KEY UPDATE.  The following INSERTs use subqueries to verify whether something should
-    // be inserted or not.  The only question I have is if two transactions from different scroll_versions in the
-    // same scroll_version_group hit the x_owner table at the same time, will two entries be made (one for each
-    // scroll_version)?  The subquery on OwnerTableInsertQuery checks against cases where one x_id is linked to two
-    // members (scroll_version) of the same group (scroll_version_group).  Since we use ReadUncommitted in the transaction,
-    // we should be safe in situations like this when two transactions run at the same time.
+    // be inserted or not.  The only possible problem is if two transactions from different edition_editors in the
+    // same edition hit the x_owner table at the same time. The subquery on OwnerTableInsertQuery checks against
+    // cases where one x_id is linked twice to the same edition_id.  Without a uniqueness constraint on x_id + edition_id
+    // in the database this query would still allow the (however unlikely) situation that two simultaneous transactions
+    // could write the same x_id + edition_id, since the query in each transaction would not see the uncommitted
+    // mutation from the other (we do not use ReadUncommitted).
     internal static class OwnedTableInsertQuery
     {
         public static string GetQuery { get; } = @"

--- a/data-access/Queries/Text.cs
+++ b/data-access/Queries/Text.cs
@@ -6,9 +6,9 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
     /// <summary>
     /// Retrieves all textual data for a chunk of text
     /// </summary>
-    /// <param Name="startId">Id of the first sign</param>
-    /// <param Name="endId">Id of the last sign</param>
-    /// <param Name="editionId">Id of the edition the text is to be taken from</param>
+    /// <param name="startId">Id of the first sign</param>
+    /// <param name="endId">Id of the last sign</param>
+    /// <param name="editionId">Id of the edition the text is to be taken from</param>
     public const string GetQuery = @"
     WITH RECURSIVE sign_ids
     AS (
@@ -106,8 +106,8 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
     /// <summary>
     /// Retrieves the first and last sign of a line
     /// </summary>
-    /// <param Name="entityId">Id of line</param>
-    /// <param Name="editionId">d of the edition the line is to be taken from</param>
+    /// <param name="entityId">Id of line</param>
+    /// <param name="editionId">d of the edition the line is to be taken from</param>
     public const string GetQuery = @"
       SELECT sign_interpretation.sign_id
       FROM  line_to_sign
@@ -126,8 +126,8 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
     /// <summary>
     /// Retrieves the first and last sign of a textFragmentName
     /// </summary>
-    /// <param Name="entityId">Id of line</param>
-    /// <param Name="editionId">d of the edition the line is to be taken from</param>
+    /// <param name="entityId">Id of line</param>
+    /// <param name="editionId">d of the edition the line is to be taken from</param>
     public const string GetQuery = @"
       SELECT sign_interpretation.sign_id
       FROM text_fragment_to_line

--- a/data-access/Queries/Text.cs
+++ b/data-access/Queries/Text.cs
@@ -45,6 +45,7 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
       
       sign_interpretation_attribute.sign_interpretation_attribute_id AS interpretationAttributeId,
       sign_interpretation_attribute.attribute_value_id AS attributeValueId,
+      sign_interpretation_attribute.sequence AS sequence,
       sign_interpretation_attribute_author.user_id AS signInterpretationAttributeAuthor,
       attribute_numeric.value AS value,
 

--- a/data-access/Queries/User.cs
+++ b/data-access/Queries/User.cs
@@ -49,9 +49,11 @@ SELECT edition_editor_id AS EditionEditionEditorId,
        may_write AS MayWrite, 
        may_lock AS MayLock, 
        may_read AS MayRead, 
-       is_admin AS IsAdmin
+       is_admin AS IsAdmin,
+       locked AS Locked
 FROM edition_editor
-WHERE edition_id = @EditionId AND user_id = @UserId";
+JOIN edition ON edition.edition_id = @EditionId
+WHERE edition_editor.edition_id = @EditionId AND user_id = @UserId";
     }
 
     /// <summary>

--- a/data-access/Queries/User.cs
+++ b/data-access/Queries/User.cs
@@ -126,6 +126,7 @@ ON DUPLICATE KEY UPDATE `type` = @Type, date_created = NOW()";
 
         public const string Activate = "ACTIVATE_ACCOUNT";
         public const string ResetPassword = "RESET_PASSWORD";
+        public const string DeleteEdition = "DELETE_EDITION";
     }
 
     /// <summary>
@@ -137,7 +138,7 @@ ON DUPLICATE KEY UPDATE `type` = @Type, date_created = NOW()";
 DELETE FROM user_email_token WHERE user_id = @UserId";
         
         public const string GetTokenQuery = @"
-DELETE FROM user_email_token WHERE token = @Token";
+DELETE FROM user_email_token WHERE token = @Token AND type = @Type";
     }
 
     /// <summary>

--- a/data-access/Queries/User.cs
+++ b/data-access/Queries/User.cs
@@ -106,6 +106,18 @@ WHERE user_email_token.token = @Token
 ";
     }
 
+    internal static class GetTokensQuery
+    {
+        public const string GetQuery = @"
+SELECT all_tokens.token AS token
+FROM SQE.user_email_token
+JOIN SQE.user_email_token AS all_tokens 
+  ON all_tokens.user_id = SQE.user_email_token.user_id
+  AND all_tokens.type = @Type
+WHERE user_email_token.token = @Token
+";
+    }
+
     /// <summary>
     /// Creates an entry in the user_email_token table for @UserId with the token @Token for the request type @Type
     /// (CreateUserEmailTokenQuery.Activate or CreateUserEmailTokenQuery.ResetPassword).
@@ -138,7 +150,7 @@ ON DUPLICATE KEY UPDATE `type` = @Type, date_created = NOW()";
 DELETE FROM user_email_token WHERE user_id = @UserId";
         
         public const string GetTokenQuery = @"
-DELETE FROM user_email_token WHERE token = @Token AND type = @Type";
+DELETE FROM user_email_token WHERE token in @Tokens AND type = @Type";
     }
 
     /// <summary>

--- a/data-access/TextRepository.cs
+++ b/data-access/TextRepository.cs
@@ -80,10 +80,7 @@ namespace SQE.SqeHttpApi.DataAccess
         public async Task<TextFragmentData> CreateTextFragmentAsync(UserInfo user,
             string fragmentName, uint? previousFragmentId, uint? nextFragmentId)
         {
-            using (var transactionScope = new TransactionScope(
-                TransactionScopeOption.Required,
-                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted })
-            )
+            using (var transactionScope = new TransactionScope())
             {
                 // Get all text fragments in the edition for sorting operations later on
                 var editionTextFragments = await GetFragmentDataAsync(user);

--- a/data-access/TextRepository.cs
+++ b/data-access/TextRepository.cs
@@ -81,9 +81,8 @@ namespace SQE.SqeHttpApi.DataAccess
             string fragmentName, uint? previousFragmentId, uint? nextFragmentId)
         {
             using (var transactionScope = new TransactionScope(
-                    TransactionScopeOption.Required,
-                    new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted }
-                )
+                TransactionScopeOption.Required,
+                new TransactionOptions() { IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted })
             )
             {
                 // Get all text fragments in the edition for sorting operations later on

--- a/data-access/TextRepository.cs
+++ b/data-access/TextRepository.cs
@@ -204,7 +204,6 @@ namespace SQE.SqeHttpApi.DataAccess
                         if (nextSignInterpretation.nextSignInterpretationId != lastNextSignInterpretation?.nextSignInterpretationId)
                         {
                             lastNextSignInterpretation = nextSignInterpretation;
-                            lastSign.nextSignInterpretations.Add(nextSignInterpretation);
                         }
     
                         if (signInterpretation.signInterpretationId != lastChar?.signInterpretationId)
@@ -212,6 +211,8 @@ namespace SQE.SqeHttpApi.DataAccess
                             lastChar = signInterpretation;
                             lastSign.signInterpretations.Add(signInterpretation);
                         }
+                        
+                        lastChar.nextSignInterpretations.Add(nextSignInterpretation);
     
                         lastCharAttribute = charAttribute;
                         lastChar.attributes.Add(charAttribute);

--- a/data-access/TextRepository.cs
+++ b/data-access/TextRepository.cs
@@ -193,7 +193,6 @@ namespace SQE.SqeHttpApi.DataAccess
                         {
                             lastLine = line;
                             lastTextFragment.lines.Add(line);
-    
                         }
     
                         if (sign.signId != lastSign?.signId)

--- a/data-access/UserRepository.cs
+++ b/data-access/UserRepository.cs
@@ -187,31 +187,29 @@ namespace SQE.SqeHttpApi.DataAccess
             string forename = null, string surname = null, string organization = null)
         {
             using (var transactionScope = new TransactionScope())
+            using (var connection = OpenConnection())
             {
-                using (var connection = OpenConnection())
-                {
-                    // Find any users with either the same  email address.
-                    await ResolveExistingUserConflictAsync(email);
+                // Find any users with either the same  email address.
+                await ResolveExistingUserConflictAsync(email);
 
-                    // Ok, the input email is unique so create the record
-                    var newUser = await connection.ExecuteAsync(CreateNewUserQuery.GetQuery,
-                        new
-                        {
-                            Email = email,
-                            Password = password,
-                            Forename = forename,
-                            Surname = surname,
-                            Organization = organization
-                        });
-                    if (newUser != 1) // Something strange must have gone wrong
-                        throw new StandardErrors.DataNotWritten("create user");
+                // Ok, the input email is unique so create the record
+                var newUser = await connection.ExecuteAsync(CreateNewUserQuery.GetQuery,
+                    new
+                    {
+                        Email = email,
+                        Password = password,
+                        Forename = forename,
+                        Surname = surname,
+                        Organization = organization
+                    });
+                if (newUser != 1) // Something strange must have gone wrong
+                    throw new StandardErrors.DataNotWritten("create user");
 
-                    // Everything went well, so create the email token so the
-                    // calling function can email the new user.
-                    var newUserObject = await CreateUserActivateTokenAsync(email);
-                    transactionScope.Complete();
-                    return newUserObject;
-                }
+                // Everything went well, so create the email token so the
+                // calling function can email the new user.
+                var newUserObject = await CreateUserActivateTokenAsync(email);
+                transactionScope.Complete();
+                return newUserObject;
             }
         }
 
@@ -338,7 +336,6 @@ namespace SQE.SqeHttpApi.DataAccess
         /// <returns></returns>
         public async Task ConfirmAccountCreationAsync(string token)
         {
-            
             using (var transactionScope = new TransactionScope())
             using (var connection = OpenConnection())
             {
@@ -413,41 +410,39 @@ namespace SQE.SqeHttpApi.DataAccess
         public async Task<DetailedUserWithToken> RequestResetForgottenPasswordAsync(string email)
         {
             using (var transactionScope = new TransactionScope())
+            using (var connection = OpenConnection())
             {
-                using (var connection = OpenConnection())
+                try
                 {
-                    try
+                    // Get the user's details via the submitted email address
+                    var columns = new List<string>() { "email", "user_id", "forename", "surname", "organization" };
+                    var where = new List<string>() { "email" };
+                    var userInfo = await connection.QuerySingleAsync<DetailedUserWithToken>(
+                        UserDetails.GetQuery(columns, where), 
+                        new { Email = email});
+                    
+                    // Generate our secret token
+                    var token = Guid.NewGuid().ToString();
+                    
+                    // Write the token to the database
+                    var tokenEntry = await connection.ExecuteAsync(CreateUserEmailTokenQuery.GetQuery(), new
                     {
-                        // Get the user's details via the submitted email address
-                        var columns = new List<string>() { "email", "user_id", "forename", "surname", "organization" };
-                        var where = new List<string>() { "email" };
-                        var userInfo = await connection.QuerySingleAsync<DetailedUserWithToken>(
-                            UserDetails.GetQuery(columns, where), 
-                            new { Email = email});
-                        
-                        // Generate our secret token
-                        var token = Guid.NewGuid().ToString();
-                        
-                        // Write the token to the database
-                        var tokenEntry = await connection.ExecuteAsync(CreateUserEmailTokenQuery.GetQuery(), new
-                        {
-                            Token = token,
-                            UserId = userInfo.UserId,
-                            Type = CreateUserEmailTokenQuery.ResetPassword
-                        });
-                        if (tokenEntry != 1)
-                            return null;
-                        
-                        // Cleanup
-                        transactionScope.Complete();
-                        
-                        // Pass the token back in the user info object
-                        userInfo.Token = token;
-                        return userInfo;
-                    }
-                    catch{} // Suppress errors here. We don't want to risk people fishing for valid email addresses,
-                            // though any errors are suppressed in the controller too.
+                        Token = token,
+                        UserId = userInfo.UserId,
+                        Type = CreateUserEmailTokenQuery.ResetPassword
+                    });
+                    if (tokenEntry != 1)
+                        return null;
+                    
+                    // Cleanup
+                    transactionScope.Complete();
+                    
+                    // Pass the token back in the user info object
+                    userInfo.Token = token;
+                    return userInfo;
                 }
+                catch{} // Suppress errors here. We don't want to risk people fishing for valid email addresses,
+                        // though any errors are suppressed in the controller too.
             }
             return null;
         }
@@ -461,36 +456,34 @@ namespace SQE.SqeHttpApi.DataAccess
         public async Task<DetailedUser> ResetForgottenPasswordAsync(string token, string password)
         {
             using (var transactionScope = new TransactionScope())
+            using (var connection = OpenConnection())
             {
-                using (var connection = OpenConnection())
-                {
-                    DetailedUser detailedUserInfo = await GetDetailedUserByTokenAsync(token);
+                var detailedUserInfo = await GetDetailedUserByTokenAsync(token);
 
-                    var resetPassword = await connection.ExecuteAsync(UpdatePasswordByToken.GetQuery, new
-                        {
-                            Token = token,
-                            Password = password
-                        });
-                    if (resetPassword != 1)
-                        throw new StandardErrors.DataNotWritten("reset password");
-
-                    // Get all unused ResetPassword tokens
-                    var tokens = await connection.QueryAsync<string>(GetTokensQuery.GetQuery, new
+                var resetPassword = await connection.ExecuteAsync(UpdatePasswordByToken.GetQuery, new
                     {
                         Token = token,
-                        Type = CreateUserEmailTokenQuery.ResetPassword
+                        Password = password
                     });
-                    
-                    // Delete them all
-                    await connection.ExecuteAsync(DeleteUserEmailTokenQuery.GetTokenQuery, new
-                    {
-                        Tokens = tokens,
-                        Type = CreateUserEmailTokenQuery.ResetPassword
-                    });
-                    
-                    transactionScope.Complete(); // Close the transaction
-                    return detailedUserInfo;
-                }
+                if (resetPassword != 1)
+                    throw new StandardErrors.DataNotWritten("reset password");
+
+                // Get all unused ResetPassword tokens
+                var tokens = await connection.QueryAsync<string>(GetTokensQuery.GetQuery, new
+                {
+                    Token = token,
+                    Type = CreateUserEmailTokenQuery.ResetPassword
+                });
+                
+                // Delete them all
+                await connection.ExecuteAsync(DeleteUserEmailTokenQuery.GetTokenQuery, new
+                {
+                    Tokens = tokens,
+                    Type = CreateUserEmailTokenQuery.ResetPassword
+                });
+                
+                transactionScope.Complete(); // Close the transaction
+                return detailedUserInfo;
             }
         }
 

--- a/data-access/data-access.csproj
+++ b/data-access/data-access.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Dapper" Version="1.60.6" />
     <PackageReference Include="MySql.Data" Version="8.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" /> 
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Polly" Version="7.1.0" /> 
   </ItemGroup>
 </Project>

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.12.1
+        image: qumranica/sqe-database:0.12.2
         container_name: SQE_Database
         environment:
             ## These must be updated when used in production

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.11.3
+        image: qumranica/sqe-database:0.12.0
         container_name: SQE_Database
         environment:
             ## These must be updated when used in production

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.12.0
+        image: qumranica/sqe-database:0.12.1
         container_name: SQE_Database
         environment:
             ## These must be updated when used in production

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.12.1
+        image: qumranica/sqe-database:0.12.2
         container_name: SQE_Database
         # These environment variables match the default db connection settings for the project.
         environment:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.12.0
+        image: qumranica/sqe-database:0.12.1
         container_name: SQE_Database
         # These environment variables match the default db connection settings for the project.
         environment:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.11.3
+        image: qumranica/sqe-database:0.12.0
         container_name: SQE_Database
         # These environment variables match the default db connection settings for the project.
         environment:

--- a/sqe-http-api/Controllers/EditionController.cs
+++ b/sqe-http-api/Controllers/EditionController.cs
@@ -25,6 +25,17 @@ namespace SQE.SqeHttpApi.Server.Controllers
         }
 
         /// <summary>
+        /// Provides a listing of all editions accessible to the current user
+        /// </summary>
+        [AllowAnonymous]
+        [HttpGet("")]
+        [ProducesResponseType(200)]
+        public async Task<ActionResult<EditionListDTO>> ListEditions()
+        {
+            return await _editionService.ListEditionsAsync(_userService.GetCurrentUserId());
+        }
+
+        /// <summary>
         /// Provides details about the specified edition and all accessible alternate editions
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
@@ -35,17 +46,6 @@ namespace SQE.SqeHttpApi.Server.Controllers
         public async Task<ActionResult<EditionGroupDTO>> GetEdition([FromRoute] uint editionId)
         {
             return await _editionService.GetEditionAsync(_userService.GetCurrentUserObject(editionId));
-        }
-
-        /// <summary>
-        /// Provides a listing of all editions accessible to the current user
-        /// </summary>
-        [AllowAnonymous]
-        [HttpGet("")]
-        [ProducesResponseType(200)]
-        public async Task<ActionResult<EditionListDTO>> ListEditions()
-        {
-            return await _editionService.ListEditionsAsync(_userService.GetCurrentUserId());
         }
 
         /// <summary>
@@ -83,7 +83,19 @@ namespace SQE.SqeHttpApi.Server.Controllers
         {
             return await _editionService.CopyEditionAsync(_userService.GetCurrentUserObject(editionId), request);
         }
-        
-        // TODO: delete edition.
+
+        /// <summary>
+        /// Provides details about the specified edition and all accessible alternate editions
+        /// </summary>
+        /// <param name="editionId">Unique Id of the desired edition</param>
+        [AllowAnonymous]
+        [HttpDelete("{editionId}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult> DeleteEdition([FromRoute] uint editionId)
+        {
+            await _editionService.DeleteEditionAsync(_userService.GetCurrentUserObject(editionId));
+            return Ok();
+        }
     }
 }

--- a/sqe-http-api/Controllers/EditionController.cs
+++ b/sqe-http-api/Controllers/EditionController.cs
@@ -97,5 +97,37 @@ namespace SQE.SqeHttpApi.Server.Controllers
             await _editionService.DeleteEditionAsync(_userService.GetCurrentUserObject(editionId));
             return Ok();
         }
+        
+        /// <summary>
+        /// Adds an editor to the specified edition
+        /// </summary>
+        /// <param name="payload">JSON object with the attributes of the new editor</param>
+        /// <param name="editionId">Unique Id of the desired edition</param>
+        /// <exception cref="NullReferenceException"></exception>
+        [HttpPost("{editionId}/editors")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(401)]
+        [ProducesResponseType(403)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<EditorRightsDTO>> AddEditionEditor([FromBody] EditorRightsDTO payload, [FromRoute] uint editionId)
+        {
+            return await _editionService.AddEditionEditor(_userService.GetCurrentUserObject(editionId), payload);
+        }
+        
+        /// <summary>
+        /// Changes the rights for an editor of the specified edition
+        /// </summary>
+        /// <param name="payload">JSON object with the attributes of the new editor</param>
+        /// <param name="editionId">Unique Id of the desired edition</param>
+        /// <exception cref="NullReferenceException"></exception>
+        [HttpPut("{editionId}/editors")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(401)]
+        [ProducesResponseType(403)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<EditorRightsDTO>> AlterEditionEditor([FromBody] EditorRightsDTO payload, [FromRoute] uint editionId)
+        {
+            return await _editionService.ChangeEditionEditorRights(_userService.GetCurrentUserObject(editionId), payload);
+        }
     }
 }

--- a/sqe-http-api/Controllers/EditionController.cs
+++ b/sqe-http-api/Controllers/EditionController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -88,13 +89,15 @@ namespace SQE.SqeHttpApi.Server.Controllers
         /// Provides details about the specified edition and all accessible alternate editions
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
+        /// <param name="optional">Optional parameters: "deleteForAllEditors"</param>
+        /// <param name="token">token required when using optional "deleteForAllEditors"</param>
         [HttpDelete("{editionId}")]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
-        public async Task<ActionResult> DeleteEdition([FromRoute] uint editionId)
+        public async Task<ActionResult<DeleteTokenDTO>> DeleteEdition([FromRoute] uint editionId, 
+            [FromQuery] string token, [FromQuery] List<string> optional)
         {
-            await _editionService.DeleteEditionAsync(_userService.GetCurrentUserObject(editionId));
-            return Ok();
+            return await _editionService.DeleteEditionAsync(_userService.GetCurrentUserObject(editionId), token, optional);
         }
         
         /// <summary>
@@ -104,10 +107,6 @@ namespace SQE.SqeHttpApi.Server.Controllers
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <exception cref="NullReferenceException"></exception>
         [HttpPost("{editionId}/editors")]
-        [ProducesResponseType(200)]
-        [ProducesResponseType(401)]
-        [ProducesResponseType(403)]
-        [ProducesResponseType(404)]
         public async Task<ActionResult<EditorRightsDTO>> AddEditionEditor([FromBody] EditorRightsDTO payload, [FromRoute] uint editionId)
         {
             return await _editionService.AddEditionEditor(_userService.GetCurrentUserObject(editionId), payload);
@@ -120,10 +119,6 @@ namespace SQE.SqeHttpApi.Server.Controllers
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <exception cref="NullReferenceException"></exception>
         [HttpPut("{editionId}/editors")]
-        [ProducesResponseType(200)]
-        [ProducesResponseType(401)]
-        [ProducesResponseType(403)]
-        [ProducesResponseType(404)]
         public async Task<ActionResult<EditorRightsDTO>> AlterEditionEditor([FromBody] EditorRightsDTO payload, [FromRoute] uint editionId)
         {
             return await _editionService.ChangeEditionEditorRights(_userService.GetCurrentUserObject(editionId), payload);

--- a/sqe-http-api/Controllers/EditionController.cs
+++ b/sqe-http-api/Controllers/EditionController.cs
@@ -88,7 +88,6 @@ namespace SQE.SqeHttpApi.Server.Controllers
         /// Provides details about the specified edition and all accessible alternate editions
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
-        [AllowAnonymous]
         [HttpDelete("{editionId}")]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]

--- a/sqe-http-api/DTOs/Editions.cs
+++ b/sqe-http-api/DTOs/Editions.cs
@@ -60,6 +60,12 @@ namespace SQE.SqeHttpApi.Server.DTOs
         public PermissionDTO permission { get; set; }
     }
 
+    public class DeleteTokenDTO
+    {
+        public uint editionId { get; set; }
+        public string token { get; set; }
+    }
+
     #region Request DTO's
     public class EditionUpdateRequestDTO
     {

--- a/sqe-http-api/DTOs/Editions.cs
+++ b/sqe-http-api/DTOs/Editions.cs
@@ -38,8 +38,10 @@ namespace SQE.SqeHttpApi.Server.DTOs
     public class EditorRightsDTO : PermissionDTO
     {
         public string email { get; set; }
-        public bool mayRead { get; set; }
-        public bool mayLock { get; set; }
+        public bool? mayRead { get; set; }
+        public bool? isAdmin { get; set; }
+        public bool? mayLock { get; set; }
+        public bool? mayWrite { get; set; }
     }
     
     public class TextEditionDTO

--- a/sqe-http-api/DTOs/Editions.cs
+++ b/sqe-http-api/DTOs/Editions.cs
@@ -39,9 +39,9 @@ namespace SQE.SqeHttpApi.Server.DTOs
     {
         public string email { get; set; }
         public bool? mayRead { get; set; }
-        public bool? isAdmin { get; set; }
+        public new bool? isAdmin { get; set; }
         public bool? mayLock { get; set; }
-        public bool? mayWrite { get; set; }
+        public new bool? mayWrite { get; set; }
     }
     
     public class TextEditionDTO

--- a/sqe-http-api/DTOs/Editions.cs
+++ b/sqe-http-api/DTOs/Editions.cs
@@ -31,8 +31,15 @@ namespace SQE.SqeHttpApi.Server.DTOs
 
     public class PermissionDTO
     {
-        public bool canWrite { get; set; }
-        public bool canAdmin { get; set; }
+        public bool mayWrite { get; set; }
+        public bool isAdmin { get; set; }
+    }
+
+    public class EditorRightsDTO : PermissionDTO
+    {
+        public string email { get; set; }
+        public bool mayRead { get; set; }
+        public bool mayLock { get; set; }
     }
     
     public class TextEditionDTO

--- a/sqe-http-api/DTOs/Sign.cs
+++ b/sqe-http-api/DTOs/Sign.cs
@@ -18,7 +18,7 @@ namespace SQE.SqeHttpApi.Server.DTOs
     public class SignInterpretationDTO
     {
         public uint signInterpretationId { get; set; }
-        public string signInterpretation { get; set; }
+        public string character { get; set; }
         public List<InterpretationAttributeDTO> attributes { get; set; }
         public List<InterpretationRoiDTO> rois { get; set; }
     }

--- a/sqe-http-api/DTOs/Sign.cs
+++ b/sqe-http-api/DTOs/Sign.cs
@@ -5,7 +5,6 @@ namespace SQE.SqeHttpApi.Server.DTOs
 {
     public class SignDTO
     {
-        public List<NextSignInterpretationDTO> nextSignInterpretations { get; set; }
         public List<SignInterpretationDTO> signInterpretations { get; set; }
     }
 
@@ -21,6 +20,7 @@ namespace SQE.SqeHttpApi.Server.DTOs
         public string character { get; set; }
         public List<InterpretationAttributeDTO> attributes { get; set; }
         public List<InterpretationRoiDTO> rois { get; set; }
+        public List<NextSignInterpretationDTO> nextSignInterpretations { get; set; }
     }
     
     public class InterpretationAttributeDTO

--- a/sqe-http-api/DTOs/Sign.cs
+++ b/sqe-http-api/DTOs/Sign.cs
@@ -26,6 +26,7 @@ namespace SQE.SqeHttpApi.Server.DTOs
     public class InterpretationAttributeDTO
     {
         public uint interpretationAttributeId { get; set; }
+        public byte sequence { get; set; }
         public uint attributeValueId { get; set; }
         public uint editorId { get; set; }
         public float value { get; set; }

--- a/sqe-http-api/Services/ArtefactService.cs
+++ b/sqe-http-api/Services/ArtefactService.cs
@@ -107,9 +107,8 @@ namespace SQE.SqeHttpApi.Server.Helpers
             {
                 if (!string.IsNullOrEmpty(position) && !GeometryValidation.ValidateTransformMatrix(position))
                     throw new StandardErrors.ImproperInputData("artefact position");
-                newArtefactId = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
-                    () => _artefactRepository.CreateNewArtefactAsync(user, editionId, masterImageId, 
-                        mask, name, position));
+                newArtefactId = await _artefactRepository.CreateNewArtefactAsync(user, editionId, masterImageId, 
+                        mask, name, position);
             }
 
             return newArtefactId != 0 

--- a/sqe-http-api/Services/ArtefactService.cs
+++ b/sqe-http-api/Services/ArtefactService.cs
@@ -107,7 +107,9 @@ namespace SQE.SqeHttpApi.Server.Helpers
             {
                 if (!string.IsNullOrEmpty(position) && !GeometryValidation.ValidateTransformMatrix(position))
                     throw new StandardErrors.ImproperInputData("artefact position");
-                newArtefactId = await _artefactRepository.CreateNewArtefactAsync(user, editionId, masterImageId, mask, name, position);
+                newArtefactId = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
+                    () => _artefactRepository.CreateNewArtefactAsync(user, editionId, masterImageId, 
+                        mask, name, position));
             }
 
             return newArtefactId != 0 

--- a/sqe-http-api/Services/EditionService.cs
+++ b/sqe-http-api/Services/EditionService.cs
@@ -131,8 +131,7 @@ namespace SQE.SqeHttpApi.Server.Helpers
         {
             EditionDTO edition;
             // Clone edition
-            var copyToEditionId = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
-                () => _editionRepo.CopyEditionAsync(user, editionInfo.copyrightHolder, editionInfo.collaborators));
+            var copyToEditionId = await _editionRepo.CopyEditionAsync(user, editionInfo.copyrightHolder, editionInfo.collaborators);
             if (user.editionId == copyToEditionId)
             {
                 // Check if is success is true, else throw error.

--- a/sqe-http-api/Services/EditionService.cs
+++ b/sqe-http-api/Services/EditionService.cs
@@ -131,7 +131,8 @@ namespace SQE.SqeHttpApi.Server.Helpers
         {
             EditionDTO edition;
             // Clone edition
-            var copyToEditionId = await _editionRepo.CopyEditionAsync(user, editionInfo.copyrightHolder, editionInfo.collaborators);
+            var copyToEditionId = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
+                () => _editionRepo.CopyEditionAsync(user, editionInfo.copyrightHolder, editionInfo.collaborators));
             if (user.editionId == copyToEditionId)
             {
                 // Check if is success is true, else throw error.

--- a/sqe-http-api/Services/ImagedObjectService.cs
+++ b/sqe-http-api/Services/ImagedObjectService.cs
@@ -145,7 +145,7 @@ namespace SQE.SqeHttpApi.Server.Helpers
         /// <summary>
         /// Get a tuple of DTO's for the recto and verso image set from a flat list of ImageDTO's.
         /// </summary>
-        /// <param Name="images"></param>
+        /// <param name="images">List of ImageDTO to be organized into recto/verso</param>
         /// <returns></returns>
         private static (ImageStackDTO recto, ImageStackDTO verso) getSides(IEnumerable<ImageDTO> images)
         {

--- a/sqe-http-api/Services/TextService.cs
+++ b/sqe-http-api/Services/TextService.cs
@@ -120,6 +120,7 @@ namespace SQE.SqeHttpApi.Server.Services
                                                         b => new InterpretationAttributeDTO()
                                                         {
                                                             interpretationAttributeId = b.interpretationAttributeId,
+                                                            sequence = b.sequence,
                                                             attributeValueId = b.attributeValueId,
                                                             editorId = b.signInterpretationAttributeAuthor,
                                                             value = b.value
@@ -194,6 +195,7 @@ namespace SQE.SqeHttpApi.Server.Services
                                         b => new InterpretationAttributeDTO()
                                         {
                                             interpretationAttributeId = b.interpretationAttributeId,
+                                            sequence = b.sequence,
                                             attributeValueId = b.attributeValueId,
                                             editorId = b.signInterpretationAttributeAuthor,
                                             value = b.value

--- a/sqe-http-api/Services/TextService.cs
+++ b/sqe-http-api/Services/TextService.cs
@@ -114,7 +114,7 @@ namespace SQE.SqeHttpApi.Server.Services
                                                 a => new SignInterpretationDTO()
                                                 {
                                                     signInterpretationId = a.signInterpretationId,
-                                                    signInterpretation = a.signInterpretation,
+                                                    character = a.character,
                                                     
                                                     attributes = a.attributes.Select(
                                                         b => new InterpretationAttributeDTO()
@@ -187,7 +187,7 @@ namespace SQE.SqeHttpApi.Server.Services
                                 a => new SignInterpretationDTO()
                                 {
                                     signInterpretationId = a.signInterpretationId,
-                                    signInterpretation = a.signInterpretation,
+                                    character = a.character,
                                     
                                     attributes = a.attributes.Select(
                                         b => new InterpretationAttributeDTO()

--- a/sqe-http-api/Services/TextService.cs
+++ b/sqe-http-api/Services/TextService.cs
@@ -62,9 +62,8 @@ namespace SQE.SqeHttpApi.Server.Services
 
             public async Task<TextFragmentDataDTO> CreateTextFragmentAsync(UserInfo user, CreateTextFragmentDTO createFragment)
             {
-                var newFragment = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
-                    ()=>_textRepo.CreateTextFragmentAsync(user, createFragment.name, 
-                        createFragment.previousTextFragmentId, createFragment.nextTextFragmentId));
+                var newFragment = await _textRepo.CreateTextFragmentAsync(user, createFragment.name, 
+                        createFragment.previousTextFragmentId, createFragment.nextTextFragmentId);
                 return new TextFragmentDataDTO(newFragment.TextFragmentId, newFragment.TextFragmentName);
             }
 

--- a/sqe-http-api/Services/TextService.cs
+++ b/sqe-http-api/Services/TextService.cs
@@ -62,8 +62,9 @@ namespace SQE.SqeHttpApi.Server.Services
 
             public async Task<TextFragmentDataDTO> CreateTextFragmentAsync(UserInfo user, CreateTextFragmentDTO createFragment)
             {
-                var newFragment = await _textRepo.CreateTextFragmentAsync(user,
-                    createFragment.name, createFragment.previousTextFragmentId, createFragment.nextTextFragmentId);
+                var newFragment = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
+                    ()=>_textRepo.CreateTextFragmentAsync(user, createFragment.name, 
+                        createFragment.previousTextFragmentId, createFragment.nextTextFragmentId));
                 return new TextFragmentDataDTO(newFragment.TextFragmentId, newFragment.TextFragmentName);
             }
 

--- a/sqe-http-api/Services/TextService.cs
+++ b/sqe-http-api/Services/TextService.cs
@@ -135,16 +135,17 @@ namespace SQE.SqeHttpApi.Server.Services
                                                             position = b.Position,
                                                             exceptional = b.Exceptional,
                                                             valuesSet = b.ValuesSet
-                                                        }).ToList()
+                                                        }).ToList(),
                                                     
+                                                    nextSignInterpretations = a.nextSignInterpretations.Select(
+                                                        b => new NextSignInterpretationDTO()
+                                                        {
+                                                        nextSignInterpretationId = b.nextSignInterpretationId,
+                                                        editorId = b.signSequenceAuthor
+                                                    }).ToList()
                                                 }).ToList(),
                                             
-                                            nextSignInterpretations = z.nextSignInterpretations.Select(
-                                                b => new NextSignInterpretationDTO()
-                                                {
-                                                    nextSignInterpretationId = b.nextSignInterpretationId,
-                                                    editorId = b.signSequenceAuthor
-                                                }).ToList()
+                                            
                                             
                                         }).ToList()
 
@@ -208,16 +209,18 @@ namespace SQE.SqeHttpApi.Server.Services
                                             position = b.Position,
                                             exceptional = b.Exceptional,
                                             valuesSet = b.ValuesSet
-                                        }).ToList()
+                                        }).ToList(),
+                                    
+                                    nextSignInterpretations = a.nextSignInterpretations.Select(
+                                        b => new NextSignInterpretationDTO()
+                                        {
+                                            nextSignInterpretationId = b.nextSignInterpretationId,
+                                            editorId = b.signSequenceAuthor
+                                        }).ToList(),
                                     
                                 }).ToList(),
                             
-                            nextSignInterpretations = z.nextSignInterpretations.Select(
-                                b => new NextSignInterpretationDTO()
-                                {
-                                    nextSignInterpretationId = b.nextSignInterpretationId,
-                                    editorId = b.signSequenceAuthor
-                                }).ToList(),
+                            
                             
                         }).ToList()
                 };

--- a/sqe-http-api/Services/UserService.cs
+++ b/sqe-http-api/Services/UserService.cs
@@ -145,8 +145,9 @@ namespace SQE.SqeHttpApi.Server.Helpers
         public async Task<DetailedUserTokenDTO> CreateNewUserAsync(NewUserRequestDTO newUserData)
         {
             // Ask the repo to create the new user
-            var createdUser = await _userRepository.CreateNewUserAsync(newUserData.email, newUserData.password,
-                forename: newUserData.forename, surname: newUserData.surname,  organization: newUserData.organization);
+            var createdUser = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
+                () => _userRepository.CreateNewUserAsync(newUserData.email, newUserData.password,
+                forename: newUserData.forename, surname: newUserData.surname,  organization: newUserData.organization));
             
             // Email the user
             await SendAccountActivationEmail(new DetailedUserWithToken()

--- a/sqe-http-api/Services/UserService.cs
+++ b/sqe-http-api/Services/UserService.cs
@@ -392,7 +392,7 @@ The Scripta Qumranica Electronica team</body></html>";
         /// HTTP request.  The UserInfo object can fetch the permissions if requested, and once
         /// the permissions have been requested, they are "cached" for the life of the object.
         /// </summary>
-        /// <param Name="editionId">Optional id of the edition the user is requesting to work with</param>
+        /// <param name="editionId">Optional id of the edition the user is requesting to work with</param>
         /// <returns></returns>
         public UserInfo GetCurrentUserObject(uint? editionId = null)
         {

--- a/sqe-http-api/Services/UserService.cs
+++ b/sqe-http-api/Services/UserService.cs
@@ -145,9 +145,8 @@ namespace SQE.SqeHttpApi.Server.Helpers
         public async Task<DetailedUserTokenDTO> CreateNewUserAsync(NewUserRequestDTO newUserData)
         {
             // Ask the repo to create the new user
-            var createdUser = await DatabaseCommunicationRetryPolicy.ExecuteRetry(
-                () => _userRepository.CreateNewUserAsync(newUserData.email, newUserData.password,
-                forename: newUserData.forename, surname: newUserData.surname,  organization: newUserData.organization));
+            var createdUser = await _userRepository.CreateNewUserAsync(newUserData.email, newUserData.password,
+                forename: newUserData.forename, surname: newUserData.surname,  organization: newUserData.organization);
             
             // Email the user
             await SendAccountActivationEmail(new DetailedUserWithToken()


### PR DESCRIPTION
This follows on the heels of the PR for edition-permissions.  It uses Polly to implement a robust retry system for those transient errors where the MariaDB specifications call for a retry (it does not retry any other errors).  It also wraps several transactions in retry policies.  Should all retries fail, the exception then continues to bubble up.  

It also adds a circuit breaker for errors in retrieving a connection from MariaDB when the error reported suggests waiting for a connection to become free before trying again.  In such cases it retries 5 times then pauses all attempts for 5 seconds with the hopes that the server will be less burdened by then.

A follow-up TODO is to add the logging system into this so that we log the retry attempts.  I will add that when I add the logging system.