### PR TITLE
fixed bugs with edition public flag

### DIFF
--- a/data-access/EditionRepository.cs
+++ b/data-access/EditionRepository.cs
@@ -62,7 +62,7 @@ namespace SQE.SqeHttpApi.DataAccess
                 Thumbnail = result.Thumbnail,
                 Locked = result.Locked,
                 LastEdit = result.LastEdit,
-                IsPublic = result.UserId == 1, // The default (public and uneditable) SQE data is associated with user_id 1.
+                IsPublic = result.IsPublic,
                 Owner = new User()
                 {
                     UserId = result.UserId,

--- a/data-access/Queries/Artefact.cs
+++ b/data-access/Queries/Artefact.cs
@@ -41,8 +41,8 @@ WHERE edition.edition_id = @EditionId
   AND $Restriction
 $Order";
 
-        private const string _userRestriction = "(edition_editor.user_id = @UserID OR edition_editor.user_id = 1)";
-        private const string _publicRestriction = "edition_editor.user_id = 1";
+        private const string _userRestriction = "(edition_editor.user_id = @UserID OR edition.public = 1)";
+        private const string _publicRestriction = "edition.public = 1";
         private const string _mask = "ASTEXT(artefact_shape.region_in_sqe_image)";
 
         private const string _order =

--- a/data-access/Queries/Edition.cs
+++ b/data-access/Queries/Edition.cs
@@ -16,6 +16,7 @@ SELECT DISTINCT ed2.edition_id AS EditionId,
     manuscript_data.name AS Name, 
     im.thumbnail_url AS Thumbnail, 
     ed2.locked AS Locked,
+    ed2.public AS IsPublic,
     ed2.manuscript_id AS ScrollId,
     current_editor.may_lock AS MayLock,
     current_editor.may_write AS MayWrite, 
@@ -24,11 +25,16 @@ SELECT DISTINCT ed2.edition_id AS EditionId,
     current_editor.user_id AS UserId, 
     current_editor_details.email AS Email 
 FROM edition AS ed1
-JOIN (SELECT edition.edition_id, edition.copyright_holder, edition.collaborators, edition.locked, edition.manuscript_id
+JOIN (SELECT edition.edition_id, 
+             edition.copyright_holder, 
+             edition.collaborators, 
+             edition.locked, 
+             edition.manuscript_id, 
+             edition.public
       FROM edition
       JOIN edition_editor USING(edition_id)
-      WHERE edition_editor.user_id = 1 $UserFilter
-        AND edition_editor.may_read = 1
+      WHERE (edition.public = 1 $UserFilter)
+        AND (edition.public = 1 OR edition_editor.may_read = 1)
       GROUP BY edition.edition_id) AS ed2 ON ed1.manuscript_id = ed2.manuscript_id
 JOIN edition_editor ON edition_editor.edition_id = ed2.edition_id
 JOIN user ON user.user_id = edition_editor.user_id
@@ -83,6 +89,7 @@ GROUP BY ed2.edition_id
             public string Email { get; set; }
             public string Collaborators { get; set; }
             public string CopyrightHolder { get; set; }
+            public bool IsPublic { get; set; }
         }
     }
 

--- a/data-access/Queries/Image.cs
+++ b/data-access/Queries/Image.cs
@@ -34,7 +34,7 @@ LEFT JOIN image_to_image_map ON SQE_image.sqe_image_id = image_to_image_map.imag
     AND image_to_image_map.image1_id = master_image.sqe_image_id 
 JOIN image_urls ON SQE_image.image_urls_id = image_urls.image_urls_id
 WHERE edition.edition_id = @EditionId
-    AND (edition_editor.user_id = 1 OR edition_editor.user_id = @UserId)
+    AND (edition.public = 1 OR edition_editor.user_id = @UserId)
 ";
         public static string GetImageQuery(bool filterFragment)
         {
@@ -82,7 +82,7 @@ FROM image_catalog
 JOIN image_to_iaa_edition_catalog USING(ImageCatalogId)
 JOIN iaa_edition_catalog USING(iaa_edition_catalog_id)
 JOIN edition USING(manuscript_id)
-WHERE edition.edition_is = @EditionId
+WHERE edition.edition_id = @EditionId
 ";
 
         public static string GetQuery(bool limitScrolls)

--- a/data-access/Queries/ImagedObject.cs
+++ b/data-access/Queries/ImagedObject.cs
@@ -15,7 +15,7 @@ JOIN edition_editor USING(edition_id)
 JOIN image_to_iaa_edition_catalog USING(iaa_edition_catalog_id)
 JOIN image_catalog USING(image_catalog_id)
 WHERE edition.edition_id = @EditionId
-  AND (edition_editor.user_id = 1 
+  AND (edition.public = 1 
          OR edition_editor.user_id = @UserId) 
   AND iaa_edition_catalog.edition_side =0
 "; 

--- a/data-access/Queries/Text.cs
+++ b/data-access/Queries/Text.cs
@@ -137,10 +137,11 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
         JOIN   sign_interpretation_attribute USING (sign_interpretation_id)
         JOIN sign_interpretation_attribute_owner USING (sign_interpretation_attribute_id)
         JOIN edition_editor ON edition_editor.edition_editor_id = @EditionId
+        JOIN edition ON edition.edition_id = @EditionId
       WHERE (attribute_value_id = 12 OR attribute_value_id = 13)
         AND text_fragment_id=@EntityId
         AND sign_interpretation_attribute_owner.edition_id=@EditionId
-        AND (edition_editor.user_id = @UserId OR edition_editor.user_id = 1)
+        AND (edition_editor.user_id = @UserId OR edition.public = 1)
       ORDER BY attribute_value_id
 ";
   }
@@ -159,10 +160,11 @@ namespace SQE.SqeHttpApi.DataAccess.Queries
           JOIN line_data USING(line_id)
           JOIN line_data_owner USING(line_data_id)
           JOIN edition_editor ON edition_editor.edition_id = @EditionId
+          JOIN edition ON edition.edition_id = @EditionId
         WHERE text_fragment_id = @TextFragmentId
           AND sign_interpretation_attribute_owner.edition_id = @EditionId
           AND line_data_owner.edition_id = @EditionId
-          AND (edition_editor.user_id = @UserId OR edition_editor.user_id = 1)
+          AND (edition_editor.user_id = @UserId OR edition.public = 1)
           AND attribute_value_id = 12
         
        UNION
@@ -204,7 +206,8 @@ FROM text_fragment_data
   JOIN text_fragment_sequence_owner ON text_fragment_sequence_owner.text_fragment_sequence_id = text_fragment_sequence.text_fragment_sequence_id
     AND text_fragment_sequence_owner.edition_id = @EditionId
   JOIN edition_editor ON edition_editor.edition_id = @EditionId
-WHERE edition_editor.user_id = @UserId OR edition_editor.user_id = 1
+  JOIN edition ON edition.edition_id = @EditionId
+WHERE edition_editor.user_id = @UserId OR edition.public = 1
 ORDER BY text_fragment_sequence.position
       ";
   }


### PR DESCRIPTION
@zmbq, this PR now properly handles the public flag in the edition table.  It also fixes those queries where we relied on user_id = 1 to find public editions.  Now we only look at the public flag to determine public visibility in the queries. Please ask Talya to try her problematic queries again and make sure this is working properly now.