### PR TITLE
Properly handle nulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SQE_API
 
 [![Build Status](https://travis-ci.org/Scripta-Qumranica-Electronica/SQE_API.svg?branch=development)](https://travis-ci.org/Scripta-Qumranica-Electronica/SQE_API)
-[![Coverage Status](https://coveralls.io/repos/github/Scripta-Qumranica-Electronica/SQE_API/badge.svg?branch=development)](https://coveralls.io/github/Scripta-Qumranica-Electronica/SQE_API?branch=integration-tests)
+[![Coverage Status](https://coveralls.io/repos/github/Scripta-Qumranica-Electronica/SQE_API/badge.svg?branch=development)](https://coveralls.io/github/Scripta-Qumranica-Electronica/SQE_API?branch=development)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Scripta-Qumranica-Electronica/SQE_API/blob/master/LICENSE.txt)
 
 Asp.Net Core web API for the [SQE project](https://www.qumranica.org/). 

--- a/sqe-api-server/HttpControllers/ArtefactController.cs
+++ b/sqe-api-server/HttpControllers/ArtefactController.cs
@@ -103,35 +103,22 @@ namespace SQE.API.Server.HttpControllers
         }
 
         /// <summary>
-        ///     Provides a listing of text fragments that may match the specified artefact
+        ///     Provides a listing of text fragments that have text in the specified artefact.
+        ///     With the optional query parameter "suggested", this endpoint will also return
+        ///     any text fragment that the system suggests might have text in the artefact.
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <param name="artefactId">Unique Id of the desired artefact</param>
+        /// <param name="optional">Add "suggested" to include possible matches suggested by the system</param>
         [AllowAnonymous]
         [HttpGet("v1/editions/{editionId}/[controller]s/{artefactId}/text-fragments")]
-        public async Task<ActionResult<TextFragmentDataListDTO>> GetArtefactTextFragments([FromRoute] uint editionId,
-            [FromRoute] uint artefactId)
+        public async Task<ActionResult<ArtefactTextFragmentMatchListDTO>> GetArtefactTextFragments([FromRoute] uint editionId,
+            [FromRoute] uint artefactId, [FromQuery] List<string> optional)
         {
             return await _artefactService.ArtefactTextFragmentsAsync(
                 await _userService.GetCurrentUserObjectAsync(editionId),
-                artefactId
-            );
-        }
-
-        /// <summary>
-        ///     Provides a listing of text fragments that may match the specified artefact
-        /// </summary>
-        /// <param name="editionId">Unique Id of the desired edition</param>
-        /// <param name="artefactId">Unique Id of the desired artefact</param>
-        [AllowAnonymous]
-        [HttpGet("v1/editions/{editionId}/[controller]s/{artefactId}/suggested-text-fragments")]
-        public async Task<ActionResult<TextFragmentDataListDTO>> GetArtefactSuggestedTextFragments(
-            [FromRoute] uint editionId,
-            [FromRoute] uint artefactId)
-        {
-            return await _artefactService.ArtefactSuggestedTextFragmentsAsync(
-                await _userService.GetCurrentUserObjectAsync(editionId),
-                artefactId
+                artefactId,
+                optional
             );
         }
 

--- a/sqe-api-server/RealtimeHubs/ArtefactHub.cs
+++ b/sqe-api-server/RealtimeHubs/ArtefactHub.cs
@@ -74,25 +74,17 @@ namespace SQE.API.Server.RealtimeHubs
         }
 
         /// <summary>
-        ///     Provides a listing of text fragments that may match the specified artefact
+        ///     Provides a listing of text fragments that have text in the specified artefact.
+        ///     With the optional query parameter "suggested", this endpoint will also return
+        ///     any text fragment that the system suggests might have text in the artefact.
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <param name="artefactId">Unique Id of the desired artefact</param>
+        /// <param name="optional">Add "suggested" to include possible matches suggested by the system</param>
         [AllowAnonymous]
-        public async Task<TextFragmentDataListDTO> GetV1EditionsEditionIdArtefactsArtefactIdTextFragments(uint editionId, uint artefactId)
+        public async Task<ArtefactTextFragmentMatchListDTO> GetV1EditionsEditionIdArtefactsArtefactIdTextFragments(uint editionId, uint artefactId, List<string> optional)
         {
-            return await _artefactService.ArtefactTextFragmentsAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId);
-        }
-
-        /// <summary>
-        ///     Provides a listing of text fragments that may match the specified artefact
-        /// </summary>
-        /// <param name="editionId">Unique Id of the desired edition</param>
-        /// <param name="artefactId">Unique Id of the desired artefact</param>
-        [AllowAnonymous]
-        public async Task<TextFragmentDataListDTO> GetV1EditionsEditionIdArtefactsArtefactIdSuggestedTextFragments(uint editionId, uint artefactId)
-        {
-            return await _artefactService.ArtefactSuggestedTextFragmentsAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId);
+            return await _artefactService.ArtefactTextFragmentsAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId, optional);
         }
 
         /// <summary>

--- a/sqe-api-server/Services/ArtefactService.cs
+++ b/sqe-api-server/Services/ArtefactService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;

--- a/sqe-api-test/ArtefactTest.cs
+++ b/sqe-api-test/ArtefactTest.cs
@@ -301,10 +301,10 @@ WHERE user_id = @UserId AND sqe_image_id IS NOT NULL";
             // Arrange
             const uint editionId = 894;
             const uint artefactId = 10058;
-            var path = $"/{version}/editions/{editionId}/{controller}/{artefactId}/suggested-text-fragments";
+            var path = $"/{version}/editions/{editionId}/{controller}/{artefactId}/text-fragments?optional=suggested";
 
             // Act
-            var (tfResponse, tfData) = await Request.SendHttpRequestAsync<string, TextFragmentDataListDTO>(
+            var (tfResponse, tfData) = await Request.SendHttpRequestAsync<string, ArtefactTextFragmentMatchListDTO>(
                 _client,
                 HttpMethod.Get,
                 path,

--- a/sqe-database-access/Helpers/DatabaseWriter.cs
+++ b/sqe-database-access/Helpers/DatabaseWriter.cs
@@ -265,7 +265,7 @@ namespace SQE.DatabaseAccess.Helpers
         {
             // Format query
             var hasNulls = (mutationRequest.Parameters.ParameterNames.Any(x =>
-                ((SqlMapper.IParameterLookup) mutationRequest.Parameters)[x] == null));
+                ((SqlMapper.IParameterLookup)mutationRequest.Parameters)[x] == null));
             var query = OwnedTableInsertQuery.GetQuery(hasNulls);
             query = query.Replace("$TableName", mutationRequest.TableName);
             query = query.Replace("$Columns", string.Join(",", mutationRequest.ColumnNames));
@@ -303,7 +303,7 @@ namespace SQE.DatabaseAccess.Helpers
                     )
                 );
                 query = query.Replace("$PrimaryKeyName", mutationRequest.TableName + "_id");
-                
+
                 insertId = await connection.QuerySingleAsync<uint>(query, mutationRequest.Parameters);
             }
             else // A new record was inserted.

--- a/sqe-database-access/Queries/Artefact.cs
+++ b/sqe-database-access/Queries/Artefact.cs
@@ -35,10 +35,10 @@ FROM artefact_shape_owner
 	JOIN artefact_shape USING(artefact_shape_id)
 	
 	LEFT JOIN artefact_position ON artefact_position.artefact_id = artefact_shape.artefact_id
-	LEFT JOIN artefact_position_owner ON artefact_position_owner.artefact_position_id =  artefact_position.artefact_position_id AND artefact_position_owner.edition_id = 1646
+	LEFT JOIN artefact_position_owner ON artefact_position_owner.artefact_position_id =  artefact_position.artefact_position_id AND artefact_position_owner.edition_id = @EditionId
 	
 	LEFT JOIN artefact_status ON artefact_status.artefact_id = artefact_shape.artefact_id
-	LEFT JOIN artefact_status_owner ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id AND artefact_status_owner.edition_id = 1646
+	LEFT JOIN artefact_status_owner ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id AND artefact_status_owner.edition_id = @EditionId
 	LEFT JOIN work_status USING(work_status_id)
 	
 	JOIN artefact_data ON artefact_data.artefact_id = artefact_shape.artefact_id

--- a/sqe-database-access/Queries/Artefact.cs
+++ b/sqe-database-access/Queries/Artefact.cs
@@ -39,6 +39,7 @@ FROM artefact_shape_owner
 	
 	LEFT JOIN artefact_status ON artefact_status.artefact_id = artefact_shape.artefact_id
 	LEFT JOIN artefact_status_owner ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id AND artefact_status_owner.edition_id = 1646
+	LEFT JOIN work_status USING(work_status_id)
 	
 	JOIN artefact_data ON artefact_data.artefact_id = artefact_shape.artefact_id
 	JOIN artefact_data_owner ON artefact_data.artefact_data_id = artefact_data_owner.artefact_data_id

--- a/sqe-database-access/Queries/Artefact.cs
+++ b/sqe-database-access/Queries/Artefact.cs
@@ -19,37 +19,43 @@ SELECT artefact_data.name AS Name,
        artefact_shape.artefact_id AS ArtefactId,
        artefact_shape.sqe_image_id AS ImageId,
        artefact_shape_owner.edition_editor_id AS MaskEditorId,
-       artefact_position.scale AS Scale,
-       artefact_position.rotate AS Rotate,
-       artefact_position.translate_x AS TranslateX,
-       artefact_position.translate_y AS TranslateY,
-       artefact_position.z_index AS ZIndex,
-       artefact_position_owner.edition_editor_id AS PositionEditorId,
+       ap.scale AS Scale,
+       ap.rotate AS Rotate,
+       ap.translate_x AS TranslateX,
+       ap.translate_y AS TranslateY,
+       ap.z_index AS ZIndex,
+       ap.edition_editor_id AS PositionEditorId,
        image_catalog.object_id AS ImagedObjectId,
        image_catalog.catalog_side AS CatalogSide, 
        SQE_image.image_catalog_id AS ImageCatalogId,
-       work_status.work_status_message AS WorkStatusMessage
+       aws.work_status_message AS WorkStatusMessage
 FROM artefact_shape_owner
     JOIN edition USING(edition_id)
 	JOIN edition_editor USING(edition_id)
 	JOIN artefact_shape USING(artefact_shape_id)
 	
-	LEFT JOIN artefact_position ON artefact_position.artefact_id = artefact_shape.artefact_id
-	LEFT JOIN artefact_position_owner ON artefact_position_owner.artefact_position_id =  artefact_position.artefact_position_id AND artefact_position_owner.edition_id = @EditionId
+	LEFT JOIN (
+	    SELECT artefact_id, scale, rotate, translate_x, translate_y, z_index, edition_editor_id
+		FROM artefact_position
+		JOIN artefact_position_owner ON artefact_position_owner.edition_id = @EditionId 
+		    AND artefact_position_owner.artefact_position_id =  artefact_position.artefact_position_id) ap USING(artefact_id)
 	
-	LEFT JOIN artefact_status ON artefact_status.artefact_id = artefact_shape.artefact_id
-	LEFT JOIN artefact_status_owner ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id AND artefact_status_owner.edition_id = @EditionId
-	LEFT JOIN work_status USING(work_status_id)
+	LEFT JOIN (
+	    SELECT artefact_id, work_status_message
+		FROM artefact_status
+		JOIN artefact_status_owner ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id 
+		    AND artefact_status_owner.edition_id = @EditionId
+		JOIN work_status USING(work_status_id)) aws USING(artefact_id)
 	
 	JOIN artefact_data ON artefact_data.artefact_id = artefact_shape.artefact_id
 	JOIN artefact_data_owner ON artefact_data.artefact_data_id = artefact_data_owner.artefact_data_id
-	    AND edition.edition_id = artefact_data_owner.edition_id
+	    AND artefact_data_owner.edition_id = @EditionId
 	
 	LEFT JOIN SQE_image USING(sqe_image_id)
 	JOIN image_catalog USING(image_catalog_id)
 
 WHERE artefact_shape_owner.edition_id = @EditionId
-  AND $Restriction
+    AND $Restriction
 $Order";
 
         private const string _userRestriction = "(edition_editor.user_id = @UserID OR edition.public = 1)";

--- a/sqe-database-access/Queries/Artefact.cs
+++ b/sqe-database-access/Queries/Artefact.cs
@@ -29,25 +29,25 @@ SELECT artefact_data.name AS Name,
        image_catalog.catalog_side AS CatalogSide, 
        SQE_image.image_catalog_id AS ImageCatalogId,
        work_status.work_status_message AS WorkStatusMessage
-FROM edition
+FROM artefact_shape_owner
+    JOIN edition USING(edition_id)
 	JOIN edition_editor USING(edition_id)
-	JOIN artefact_shape_owner USING(edition_id)
 	JOIN artefact_shape USING(artefact_shape_id)
-	LEFT JOIN artefact_position_owner ON artefact_position_owner.edition_id = @EditionId
+	
 	LEFT JOIN artefact_position ON artefact_position.artefact_id = artefact_shape.artefact_id
-	    AND artefact_position.artefact_position_id = artefact_position_owner.artefact_position_id
-	LEFT JOIN artefact_status_owner ON artefact_status_owner.edition_id = @EditionId
-    LEFT JOIN artefact_status ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id
-    	AND artefact_shape.artefact_id = artefact_status.artefact_id
-    LEFT JOIN work_status ON artefact_status.work_status_id = work_status.work_status_id
+	LEFT JOIN artefact_position_owner ON artefact_position_owner.artefact_position_id =  artefact_position.artefact_position_id AND artefact_position_owner.edition_id = 1646
+	
+	LEFT JOIN artefact_status ON artefact_status.artefact_id = artefact_shape.artefact_id
+	LEFT JOIN artefact_status_owner ON artefact_status_owner.artefact_status_id = artefact_status.artefact_status_id AND artefact_status_owner.edition_id = 1646
+	
 	JOIN artefact_data ON artefact_data.artefact_id = artefact_shape.artefact_id
 	JOIN artefact_data_owner ON artefact_data.artefact_data_id = artefact_data_owner.artefact_data_id
 	    AND edition.edition_id = artefact_data_owner.edition_id
 	
-	JOIN SQE_image USING(sqe_image_id)
+	LEFT JOIN SQE_image USING(sqe_image_id)
 	JOIN image_catalog USING(image_catalog_id)
 
-WHERE edition.edition_id = @EditionId
+WHERE artefact_shape_owner.edition_id = @EditionId
   AND $Restriction
 $Order";
 

--- a/sqe-database-access/Queries/MutateQueries.cs
+++ b/sqe-database-access/Queries/MutateQueries.cs
@@ -26,7 +26,7 @@ FROM dual
 WHERE NOT EXISTS
   ( SELECT $Columns                 # This is basically an adhoc uniqueness constraint, which Itay wants to protect
     FROM $TableName                 # against any database schema updates that fail to set a proper uniqueness
-    WHERE ($Columns) {(hasNulls ? "<=>": "=")} ($Values)    # constraint.  It is very fast if the proper uniqueness constraint already exists.
+    WHERE ($Columns) {(hasNulls ? "<=>" : "=")} ($Values)    # constraint.  It is very fast if the proper uniqueness constraint already exists.
   ) LIMIT 1
 ";
         }
@@ -47,10 +47,10 @@ WHERE NOT EXISTS
             return $@"
 SELECT $PrimaryKeyName
 FROM $TableName
-WHERE ($Columns) {(hasNulls ? "<=>": "=")} ($Values)
+WHERE ($Columns) {(hasNulls ? "<=>" : "=")} ($Values)
 LIMIT 1
-";     
-        } 
+";
+        }
     }
 
     internal static class OwnerTableInsertQuery

--- a/sqe-database-access/Queries/MutateQueries.cs
+++ b/sqe-database-access/Queries/MutateQueries.cs
@@ -31,12 +31,14 @@ WHERE NOT EXISTS
     // above, but that would mysteriously set the last insert id to something incorrect every other time I ran the
     // query.  Thus, I need to run this after OwnedTableInsertQuery in order to get the correct primary key id.
     // So the cost for not trusting ON DUPLICATE KEY UPDATE is two extra queries (the subquery above and this one here).
+    // Note that the NULL-safe equal to operator must be used here, because we don't want duplicate entries due to 
+    // null values (also, this overcomes the limitations of the unique constraints, since nulls are not unique).
     internal static class OwnedTableIdQuery
     {
         public static string GetQuery { get; } = @"
 SELECT $PrimaryKeyName
 FROM $TableName
-WHERE ($Columns) = ($Values)
+WHERE ($Columns) <=> ($Values)
 LIMIT 1
 ";
     }

--- a/sqe-dto/TextFragment.cs
+++ b/sqe-dto/TextFragment.cs
@@ -20,6 +20,25 @@ namespace SQE.API.DTO
         public uint editorId { get; set; }
     }
 
+    public class ArtefactTextFragmentMatchDTO : TextFragmentDataDTO
+    {
+        /// <summary>
+        /// This DTO contains the data of a text fragment that has been requested via
+        /// artefact id.
+        /// </summary>
+        /// <param name="id">Id of the text fragment</param>
+        /// <param name="name">Name of the text fragment</param>
+        /// <param name="editorId">Id of the editor who sefined the text fragment</param>
+        /// <param name="suggested">Whether this text fragment was suggest by the system (true)
+        /// or is a definite match (false)</param>
+        public ArtefactTextFragmentMatchDTO(uint id, string name, uint editorId, bool suggested) : base(id, name, editorId)
+        {
+            this.suggested = suggested;
+        }
+
+        public bool suggested { get; set; }
+    }
+
     public class TextFragmentDataListDTO
     {
         public TextFragmentDataListDTO(List<TextFragmentDataDTO> textFragments)
@@ -28,6 +47,16 @@ namespace SQE.API.DTO
         }
 
         public List<TextFragmentDataDTO> textFragments { get; set; }
+    }
+
+    public class ArtefactTextFragmentMatchListDTO
+    {
+        public ArtefactTextFragmentMatchListDTO(List<ArtefactTextFragmentMatchDTO> textFragments)
+        {
+            this.textFragments = textFragments;
+        }
+
+        public List<ArtefactTextFragmentMatchDTO> textFragments { get; set; }
     }
 
     public class TextFragmentDTO

--- a/ts-dtos/sqe-dtos.ts
+++ b/ts-dtos/sqe-dtos.ts
@@ -217,8 +217,16 @@ export interface TextFragmentDataDTO {
     editorId: number;
 }
 
+export interface ArtefactTextFragmentMatchDTO extends TextFragmentDataDTO {
+    suggested: boolean;
+}
+
 export interface TextFragmentDataListDTO {
     textFragments: TextFragmentDataDTO[];
+}
+
+export interface ArtefactTextFragmentMatchListDTO {
+    textFragments: ArtefactTextFragmentMatchDTO[];
 }
 
 export interface TextFragmentDTO {


### PR DESCRIPTION
This PR fixes an error where duplicate entries were created in database tables that allowed nulls, when null values were being used (this was happening in the artefact_position table). In proper SQL99 NULL = NULL always returns false, so the API now uses the <=> comparator if any NULL values are detected (NULL <=> NULL returns true).  It also fixes a malformed query to get artefacts belonging to an edition.

I've also consolidated the endpoints /v1/editions/editionId/artefacts/artefactId/text-fragments and /v1/editions/editionId/artefacts/artefactId/text-fragments/suggests, as you requested, into a single endpoint /v1/editions/editionId/artefacts/artefactId/text-fragments, which can take the query variable ?optional=suggested, to also return text fragment to artefact matches that are suggested by the system (see the DTO which has a boolean specifying whether a match is only a suggested one or a real one).