### PR TITLE
Fix batch rois

### DIFF
--- a/sqe-database-access/Models/SignInterpretation.cs
+++ b/sqe-database-access/Models/SignInterpretation.cs
@@ -13,7 +13,22 @@ namespace SQE.DatabaseAccess.Models
 
     public class NextSignInterpretation
     {
-        public uint nextSignInterpretationId { get; set; }
-        public uint signSequenceAuthor { get; set; }
+        public uint nextSignInterpretationId { get; }
+        public uint signSequenceAuthor { get; }
+        
+        // The override for Equals and GetHashCode methods here enable the
+        // HashSet nextSignInterpretations of the SignInterpretation object
+        // to ensure that no duplicate values will be inserted into the set.
+        public override bool Equals(object obj)
+        {
+            return obj is NextSignInterpretation q 
+                   && q.nextSignInterpretationId == this.nextSignInterpretationId 
+                   && q.signSequenceAuthor == this.signSequenceAuthor;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.nextSignInterpretationId.GetHashCode() ^ this.signSequenceAuthor.GetHashCode();
+        }
     }
 }

--- a/sqe-database-access/RoiRepository.cs
+++ b/sqe-database-access/RoiRepository.cs
@@ -94,6 +94,7 @@ namespace SQE.DatabaseAccess
                 var createdRois = CreateRoisAsync(editionUser, newRois);
                 var updatedRois = UpdateRoisAsync(editionUser, updateRois);
                 var deletedRois = DeletRoisAsync(editionUser, deleteRois);
+                transactionScope.Complete();
                 return (createdRois, updatedRois, deletedRois);
             }
         }


### PR DESCRIPTION
This fixes the bug that POSTs to the batch ROI endpoint would return a successful status and object, but were not actually stored in the database (I forgot to commit the transaction).

A smaller bugfix here is the return data from the text-fragment endpoints, which would send out duplicates of the nextSignInterpretation objects (the object needed a proper Equals and GetHashCode override).