### PR TITLE
Chelem tests

### DIFF
--- a/sqe-api-server/HttpControllers/ArtefactController.cs
+++ b/sqe-api-server/HttpControllers/ArtefactController.cs
@@ -112,8 +112,10 @@ namespace SQE.API.Server.HttpControllers
         /// <param name="optional">Add "suggested" to include possible matches suggested by the system</param>
         [AllowAnonymous]
         [HttpGet("v1/editions/{editionId}/[controller]s/{artefactId}/text-fragments")]
-        public async Task<ActionResult<ArtefactTextFragmentMatchListDTO>> GetArtefactTextFragments([FromRoute] uint editionId,
-            [FromRoute] uint artefactId, [FromQuery] List<string> optional)
+        public async Task<ActionResult<ArtefactTextFragmentMatchListDTO>> GetArtefactTextFragments(
+            [FromRoute] uint editionId,
+            [FromRoute] uint artefactId,
+            [FromQuery] List<string> optional)
         {
             return await _artefactService.ArtefactTextFragmentsAsync(
                 await _userService.GetCurrentUserObjectAsync(editionId),

--- a/sqe-api-server/RealtimeHubs/ArtefactHub.cs
+++ b/sqe-api-server/RealtimeHubs/ArtefactHub.cs
@@ -24,9 +24,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">A CreateArtefactDTO with the data for the new artefact</param>
         [Authorize]
         public async Task<ArtefactDTO> PostV1EditionsEditionIdArtefacts(uint editionId, CreateArtefactDTO payload)
-        {
-            return await _artefactService.CreateArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), payload, clientId: Context.ConnectionId);
-        }
+        { return await _artefactService.CreateArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), payload, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Deletes the specified artefact
@@ -35,9 +33,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="editionId">Unique Id of the desired edition</param>
         [Authorize]
         public async Task DeleteV1EditionsEditionIdArtefactsArtefactId(uint editionId, uint artefactId)
-        {
-            await _artefactService.DeleteArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), artefactId, clientId: Context.ConnectionId);
-        }
+        { await _artefactService.DeleteArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), artefactId, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Provides a listing of all artefacts that are part of the specified edition
@@ -47,9 +43,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="optional">Add "masks" to include artefact polygons and "images" to include image data</param>
         [AllowAnonymous]
         public async Task<ArtefactDTO> GetV1EditionsEditionIdArtefactsArtefactId(uint editionId, uint artefactId, List<string> optional)
-        {
-            return await _artefactService.GetEditionArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId, optional);
-        }
+        { return await _artefactService.GetEditionArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId, optional); }
 
         /// <summary>
         ///     Provides a listing of all rois belonging to an artefact in the specified edition
@@ -58,9 +52,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="editionId">Unique Id of the desired edition</param>
         [AllowAnonymous]
         public async Task<InterpretationRoiDTOList> GetV1EditionsEditionIdArtefactsArtefactIdRois(uint editionId, uint artefactId)
-        {
-            return await _roiService.GetRoisByArtefactIdAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId);
-        }
+        { return await _roiService.GetRoisByArtefactIdAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId); }
 
         /// <summary>
         ///     Provides a listing of all artefacts that are part of the specified edition
@@ -69,9 +61,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="optional">Add "masks" to include artefact polygons and "images" to include image data</param>
         [AllowAnonymous]
         public async Task<ArtefactListDTO> GetV1EditionsEditionIdArtefacts(uint editionId, List<string> optional)
-        {
-            return await _artefactService.GetEditionArtefactListingsAsync(await _userService.GetCurrentUserObjectAsync(editionId), optional);
-        }
+        { return await _artefactService.GetEditionArtefactListingsAsync(await _userService.GetCurrentUserObjectAsync(editionId), optional); }
 
         /// <summary>
         ///     Provides a listing of text fragments that have text in the specified artefact.
@@ -83,9 +73,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="optional">Add "suggested" to include possible matches suggested by the system</param>
         [AllowAnonymous]
         public async Task<ArtefactTextFragmentMatchListDTO> GetV1EditionsEditionIdArtefactsArtefactIdTextFragments(uint editionId, uint artefactId, List<string> optional)
-        {
-            return await _artefactService.ArtefactTextFragmentsAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId, optional);
-        }
+        { return await _artefactService.ArtefactTextFragmentsAsync(await _userService.GetCurrentUserObjectAsync(editionId), artefactId, optional); }
 
         /// <summary>
         ///     Updates the specified artefact
@@ -95,9 +83,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">An UpdateArtefactDTO with the desired alterations to the artefact</param>
         [Authorize]
         public async Task<ArtefactDTO> PutV1EditionsEditionIdArtefactsArtefactId(uint editionId, uint artefactId, UpdateArtefactDTO payload)
-        {
-            return await _artefactService.UpdateArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), artefactId, payload, clientId: Context.ConnectionId);
-        }
+        { return await _artefactService.UpdateArtefactAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), artefactId, payload, clientId: Context.ConnectionId); }
 
     }
 }

--- a/sqe-api-server/RealtimeHubs/EditionHub.cs
+++ b/sqe-api-server/RealtimeHubs/EditionHub.cs
@@ -24,9 +24,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">JSON object with the attributes of the new editor</param>
         [Authorize]
         public async Task<EditorRightsDTO> PostV1EditionsEditionIdEditors(uint editionId, EditorRightsDTO payload)
-        {
-            return await _editionService.AddEditionEditor(await _userService.GetCurrentUserObjectAsync(editionId, admin: true), payload, clientId: Context.ConnectionId);
-        }
+        { return await _editionService.AddEditionEditor(await _userService.GetCurrentUserObjectAsync(editionId, admin: true), payload, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Changes the rights for an editor of the specified edition
@@ -35,9 +33,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">JSON object with the attributes of the new editor</param>
         [Authorize]
         public async Task<EditorRightsDTO> PutV1EditionsEditionIdEditors(uint editionId, EditorRightsDTO payload)
-        {
-            return await _editionService.ChangeEditionEditorRights(await _userService.GetCurrentUserObjectAsync(editionId, admin: true), payload, clientId: Context.ConnectionId);
-        }
+        { return await _editionService.ChangeEditionEditorRights(await _userService.GetCurrentUserObjectAsync(editionId, admin: true), payload, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Creates a copy of the specified edition
@@ -46,9 +42,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="request">JSON object with the attributes to be changed in the copied edition</param>
         [Authorize]
         public async Task<EditionDTO> PostV1EditionsEditionId(uint editionId, EditionCopyDTO request)
-        {
-            return await _editionService.CopyEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId), request, clientId: Context.ConnectionId);
-        }
+        { return await _editionService.CopyEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId), request, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Provides details about the specified edition and all accessible alternate editions
@@ -58,9 +52,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="token">token required when using optional 'deleteForAllEditors'</param>
         [Authorize]
         public async Task<DeleteTokenDTO> DeleteV1EditionsEditionId(uint editionId, List<string> optional, string token)
-        {
-            return await _editionService.DeleteEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), token, optional, clientId: Context.ConnectionId);
-        }
+        { return await _editionService.DeleteEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), token, optional, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Provides details about the specified edition and all accessible alternate editions
@@ -68,18 +60,14 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="editionId">Unique Id of the desired edition</param>
         [AllowAnonymous]
         public async Task<EditionGroupDTO> GetV1EditionsEditionId(uint editionId)
-        {
-            return await _editionService.GetEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId));
-        }
+        { return await _editionService.GetEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId)); }
 
         /// <summary>
         ///     Provides a listing of all editions accessible to the current user
         /// </summary>
         [AllowAnonymous]
         public async Task<EditionListDTO> GetV1Editions()
-        {
-            return await _editionService.ListEditionsAsync(_userService.GetCurrentUserId());
-        }
+        { return await _editionService.ListEditionsAsync(_userService.GetCurrentUserId()); }
 
         /// <summary>
         ///     Updates data for the specified edition
@@ -88,9 +76,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="request">JSON object with the attributes to be updated</param>
         [Authorize]
         public async Task<EditionDTO> PutV1EditionsEditionId(uint editionId, EditionUpdateRequestDTO request)
-        {
-            return await _editionService.UpdateEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), request, clientId: Context.ConnectionId);
-        }
+        { return await _editionService.UpdateEditionAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), request, clientId: Context.ConnectionId); }
 
     }
 }

--- a/sqe-api-server/RealtimeHubs/ImagedObjectHub.cs
+++ b/sqe-api-server/RealtimeHubs/ImagedObjectHub.cs
@@ -26,9 +26,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="optional">Set 'artefacts' to receive related artefact data and 'masks' to include the artefact masks</param>
         [AllowAnonymous]
         public async Task<ImagedObjectDTO> GetV1EditionsEditionIdImagedObjectsImagedObjectId(uint editionId, string imagedObjectId, List<string> optional)
-        {
-            return await _imagedObjectService.GetImagedObjectAsync(await _userService.GetCurrentUserObjectAsync(editionId), imagedObjectId, optional);
-        }
+        { return await _imagedObjectService.GetImagedObjectAsync(await _userService.GetCurrentUserObjectAsync(editionId), imagedObjectId, optional); }
 
         /// <summary>
         ///     Provides a listing of imaged objects related to the specified edition, can include images and also their masks with
@@ -38,18 +36,14 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="optional">Set 'artefacts' to receive related artefact data and 'masks' to include the artefact masks</param>
         [AllowAnonymous]
         public async Task<ImagedObjectListDTO> GetV1EditionsEditionIdImagedObjects(uint editionId, List<string> optional)
-        {
-            return await _imagedObjectService.GetImagedObjectsAsync(await _userService.GetCurrentUserObjectAsync(editionId), optional);
-        }
+        { return await _imagedObjectService.GetImagedObjectsAsync(await _userService.GetCurrentUserObjectAsync(editionId), optional); }
 
         /// <summary>
         ///     Provides a list of all institutional image providers.
         /// </summary>
         [AllowAnonymous]
         public async Task<ImageInstitutionListDTO> GetV1ImagedObjectsInstitutions()
-        {
-            return await _imageService.GetImageInstitutionsAsync();
-        }
+        { return await _imageService.GetImageInstitutionsAsync(); }
 
     }
 }

--- a/sqe-api-server/RealtimeHubs/RoiHub.cs
+++ b/sqe-api-server/RealtimeHubs/RoiHub.cs
@@ -23,9 +23,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="roiId">A JSON object with the new ROI to be created</param>
         [AllowAnonymous]
         public async Task<InterpretationRoiDTO> GetV1EditionsEditionIdRoisRoiId(uint editionId, uint roiId)
-        {
-            return await _roiService.GetRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId), roiId);
-        }
+        { return await _roiService.GetRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId), roiId); }
 
         /// <summary>
         ///     Creates new sign ROI in the given edition of a scroll
@@ -34,9 +32,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="newRoi">A JSON object with the new ROI to be created</param>
         [Authorize]
         public async Task<InterpretationRoiDTO> PostV1EditionsEditionIdRois(uint editionId, SetInterpretationRoiDTO newRoi)
-        {
-            return await _roiService.CreateRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), newRoi, clientId: Context.ConnectionId);
-        }
+        { return await _roiService.CreateRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), newRoi, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Creates new sign ROI's in the given edition of a scroll
@@ -45,9 +41,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="newRois">A JSON object with an array of the new ROI's to be created</param>
         [Authorize]
         public async Task<InterpretationRoiDTOList> PostV1EditionsEditionIdRoisBatch(uint editionId, SetInterpretationRoiDTOList newRois)
-        {
-            return await _roiService.CreateRoisAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), newRois, clientId: Context.ConnectionId);
-        }
+        { return await _roiService.CreateRoisAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), newRois, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Processes a series of create/update/delete ROI requests in the given edition of a scroll
@@ -56,9 +50,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="rois">A JSON object with all the roi edits to be performed</param>
         [Authorize]
         public async Task<BatchEditRoiResponseDTO> PostV1EditionsEditionIdRoisBatchEdit(uint editionId, BatchEditRoiDTO rois)
-        {
-            return await _roiService.BatchEditRoisAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), rois, clientId: Context.ConnectionId);
-        }
+        { return await _roiService.BatchEditRoisAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), rois, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Update an existing sign ROI in the given edition of a scroll
@@ -68,9 +60,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="updateRoi">A JSON object with the updated ROI details</param>
         [Authorize]
         public async Task<UpdatedInterpretationRoiDTO> PutV1EditionsEditionIdRoisRoiId(uint editionId, uint roiId, SetInterpretationRoiDTO updateRoi)
-        {
-            return await _roiService.UpdateRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), roiId, updateRoi, clientId: Context.ConnectionId);
-        }
+        { return await _roiService.UpdateRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), roiId, updateRoi, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Update existing sign ROI's in the given edition of a scroll
@@ -79,9 +69,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="updateRois">A JSON object with an array of the updated ROI details</param>
         [Authorize]
         public async Task<UpdatedInterpretationRoiDTOList> PutV1EditionsEditionIdRoisBatch(uint editionId, InterpretationRoiDTOList updateRois)
-        {
-            return await _roiService.UpdateRoisAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), updateRois, clientId: Context.ConnectionId);
-        }
+        { return await _roiService.UpdateRoisAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), updateRois, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Deletes a sign ROI from the given edition of a scroll
@@ -90,9 +78,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="editionId">Id of the edition</param>
         [Authorize]
         public async Task DeleteV1EditionsEditionIdRoisRoiId(uint editionId, uint roiId)
-        {
-            await _roiService.DeleteRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), roiId, clientId: Context.ConnectionId);
-        }
+        { await _roiService.DeleteRoiAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), roiId, clientId: Context.ConnectionId); }
 
     }
 }

--- a/sqe-api-server/RealtimeHubs/TextHub.cs
+++ b/sqe-api-server/RealtimeHubs/TextHub.cs
@@ -23,9 +23,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="editionId">Id of the edition</param>
         [Authorize]
         public async Task<TextFragmentDataDTO> PostV1EditionsEditionIdTextFragments(uint editionId, CreateTextFragmentDTO createFragment)
-        {
-            return await _textService.CreateTextFragmentAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), createFragment, clientId: Context.ConnectionId);
-        }
+        { return await _textService.CreateTextFragmentAsync(await _userService.GetCurrentUserObjectAsync(editionId, true), createFragment, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Retrieves the ids of all fragments in the given edition of a scroll
@@ -34,9 +32,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>An array of the text fregment ids in correct sequence</returns>
         [AllowAnonymous]
         public async Task<TextFragmentDataListDTO> GetV1EditionsEditionIdTextFragments(uint editionId)
-        {
-            return await _textService.GetFragmentDataAsync(await _userService.GetCurrentUserObjectAsync(editionId));
-        }
+        { return await _textService.GetFragmentDataAsync(await _userService.GetCurrentUserObjectAsync(editionId)); }
 
         /// <summary>
         ///     Retrieves the ids of all lines in the given textFragmentName
@@ -46,9 +42,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>An array of the line ids in the proper sequence</returns>
         [AllowAnonymous]
         public async Task<ArtefactDataListDTO> GetV1EditionsEditionIdTextFragmentsTextFragmentIdArtefacts(uint editionId, uint textFragmentId)
-        {
-            return await _textService.GetArtefactsAsync(await _userService.GetCurrentUserObjectAsync(editionId), textFragmentId);
-        }
+        { return await _textService.GetArtefactsAsync(await _userService.GetCurrentUserObjectAsync(editionId), textFragmentId); }
 
         /// <summary>
         ///     Retrieves the ids of all lines in the given textFragmentName
@@ -58,9 +52,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>An array of the line ids in the proper sequence</returns>
         [AllowAnonymous]
         public async Task<LineDataListDTO> GetV1EditionsEditionIdTextFragmentsTextFragmentIdLines(uint editionId, uint textFragmentId)
-        {
-            return await _textService.GetLineIdsAsync(await _userService.GetCurrentUserObjectAsync(editionId), textFragmentId);
-        }
+        { return await _textService.GetLineIdsAsync(await _userService.GetCurrentUserObjectAsync(editionId), textFragmentId); }
 
         /// <summary>
         ///     Retrieves all signs and their data from the given textFragmentName
@@ -73,9 +65,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// </returns>
         [AllowAnonymous]
         public async Task<TextEditionDTO> GetV1EditionsEditionIdTextFragmentsTextFragmentId(uint editionId, uint textFragmentId)
-        {
-            return await _textService.GetFragmentByIdAsync(await _userService.GetCurrentUserObjectAsync(editionId), textFragmentId);
-        }
+        { return await _textService.GetFragmentByIdAsync(await _userService.GetCurrentUserObjectAsync(editionId), textFragmentId); }
 
         /// <summary>
         ///     Retrieves all signs and their data from the given line
@@ -88,9 +78,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// </returns>
         [AllowAnonymous]
         public async Task<LineTextDTO> GetV1EditionsEditionIdLinesLineId(uint editionId, uint lineId)
-        {
-            return await _textService.GetLineByIdAsync(await _userService.GetCurrentUserObjectAsync(editionId), lineId);
-        }
+        { return await _textService.GetLineByIdAsync(await _userService.GetCurrentUserObjectAsync(editionId), lineId); }
 
     }
 }

--- a/sqe-api-server/RealtimeHubs/UserHub.cs
+++ b/sqe-api-server/RealtimeHubs/UserHub.cs
@@ -26,9 +26,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// </returns>
         [AllowAnonymous]
         public async Task<DetailedUserTokenDTO> PostV1UsersLogin(LoginRequestDTO payload)
-        {
-            return await _userService.AuthenticateAsync(payload.email, payload.password, clientId: Context.ConnectionId);
-        }
+        { return await _userService.AuthenticateAsync(payload.email, payload.password, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Allows a user who has not yet activated their account to change their email address. This will not work if the user
@@ -37,9 +35,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">JSON object with the current email address and the new desired email address</param>
         [AllowAnonymous]
         public async Task PostV1UsersChangeUnactivatedEmail(UnactivatedEmailUpdateRequestDTO payload)
-        {
-            await _userService.UpdateUnactivatedAccountEmailAsync(payload.email, payload.newEmail, clientId: Context.ConnectionId);
-        }
+        { await _userService.UpdateUnactivatedAccountEmailAsync(payload.email, payload.newEmail, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Uses the secret token from /users/forgot-password to validate a reset of the user's password
@@ -47,9 +43,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">A JSON object with the secret token and the new password</param>
         [AllowAnonymous]
         public async Task PostV1UsersChangeForgottenPassword(ResetForgottenUserPasswordRequestDTO payload)
-        {
-            await _userService.ResetLostPasswordAsync(payload.token, payload.password, clientId: Context.ConnectionId);
-        }
+        { await _userService.ResetLostPasswordAsync(payload.token, payload.password, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Changes the password for the currently logged in user
@@ -57,9 +51,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">A JSON object with the old password and the new password</param>
         [Authorize]
         public async Task PostV1UsersChangePassword(ResetLoggedInUserPasswordRequestDTO payload)
-        {
-            await _userService.ChangePasswordAsync(_userService.GetCurrentUserId(), payload.oldPassword, payload.newPassword, clientId: Context.ConnectionId);
-        }
+        { await _userService.ChangePasswordAsync(_userService.GetCurrentUserId(), payload.oldPassword, payload.newPassword, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Updates a user's registration details.  Note that the if the email address has changed, the account will be set to
@@ -72,9 +64,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>Returns a DetailedUserDTO with the updated user account details</returns>
         [Authorize]
         public async Task<DetailedUserDTO> PutV1Users(UserUpdateRequestDTO payload)
-        {
-            return await _userService.UpdateUserAsync(_userService.GetCurrentUserId(), payload, clientId: Context.ConnectionId);
-        }
+        { return await _userService.UpdateUserAsync(_userService.GetCurrentUserId(), payload, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Confirms registration of new user account.
@@ -83,9 +73,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>Returns a DetailedUserDTO for the confirmed account</returns>
         [AllowAnonymous]
         public async Task PostV1UsersConfirmRegistration(AccountActivationRequestDTO payload)
-        {
-            await _userService.ConfirmUserRegistrationAsync(payload.token, clientId: Context.ConnectionId);
-        }
+        { await _userService.ConfirmUserRegistrationAsync(payload.token, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Sends a secret token to the user's email to allow password reset.
@@ -93,9 +81,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">JSON object with the email address for the user who wants to reset a lost password</param>
         [AllowAnonymous]
         public async Task PostV1UsersForgotPassword(ResetUserPasswordRequestDTO payload)
-        {
-            await _userService.RequestResetLostPasswordAsync(payload.email, clientId: Context.ConnectionId);
-        }
+        { await _userService.RequestResetLostPasswordAsync(payload.email, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Provides the user details for a user with valid JWT in the Authorize header
@@ -103,9 +89,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>A UserDTO for user account.</returns>
         [Authorize]
         public async Task<UserDTO> GetV1Users()
-        {
-            return await _userService.GetCurrentUser();
-        }
+        { return await _userService.GetCurrentUser(); }
 
         /// <summary>
         ///     Creates a new user with the submitted data.
@@ -114,9 +98,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <returns>Returns a UserDTO for the newly created account</returns>
         [AllowAnonymous]
         public async Task<UserDTO> PostV1Users(NewUserRequestDTO payload)
-        {
-            return await _userService.CreateNewUserAsync(payload, clientId: Context.ConnectionId);
-        }
+        { return await _userService.CreateNewUserAsync(payload, clientId: Context.ConnectionId); }
 
         /// <summary>
         ///     Sends a new activation email for the user's account. This will not work if the user account associated with the
@@ -125,9 +107,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// <param name="payload">JSON object with the current email address and the new desired email address</param>
         [AllowAnonymous]
         public async Task PostV1UsersResendActivationEmail(ResendUserAccountActivationRequestDTO payload)
-        {
-            await _userService.ResendActivationEmail(payload.email, clientId: Context.ConnectionId);
-        }
+        { await _userService.ResendActivationEmail(payload.email, clientId: Context.ConnectionId); }
 
     }
 }

--- a/sqe-api-server/Services/ArtefactService.cs
+++ b/sqe-api-server/Services/ArtefactService.cs
@@ -32,6 +32,7 @@ namespace SQE.API.Server.Services
             string clientId = null);
 
         Task<NoContentResult> DeleteArtefactAsync(EditionUserInfo editionUser, uint artefactId, string clientId = null);
+
         Task<ArtefactTextFragmentMatchListDTO> ArtefactTextFragmentsAsync(EditionUserInfo editionUser,
             uint artefactId,
             List<string> optional);
@@ -200,7 +201,14 @@ namespace SQE.API.Server.Services
 
             var realMatches = new ArtefactTextFragmentMatchListDTO(
                 (await _artefactRepository.ArtefactTextFragmentsAsync(editionUser, artefactId))
-                .Select(x => new ArtefactTextFragmentMatchDTO(x.TextFragmentId, x.TextFragmentName, x.EditionEditorId, false))
+                .Select(
+                    x => new ArtefactTextFragmentMatchDTO(
+                        x.TextFragmentId,
+                        x.TextFragmentName,
+                        x.EditionEditorId,
+                        false
+                    )
+                )
                 .ToList()
             );
             if (!suggestedResults) return realMatches;
@@ -216,7 +224,9 @@ namespace SQE.API.Server.Services
         {
             return new ArtefactTextFragmentMatchListDTO(
                 (await _artefactRepository.ArtefactSuggestedTextFragmentsAsync(editionUser, artefactId))
-                .Select(x => new ArtefactTextFragmentMatchDTO(x.TextFragmentId, x.TextFragmentName, x.EditionEditorId, true))
+                .Select(
+                    x => new ArtefactTextFragmentMatchDTO(x.TextFragmentId, x.TextFragmentName, x.EditionEditorId, true)
+                )
                 .ToList()
             );
         }

--- a/sqe-api-server/Services/TextService.cs
+++ b/sqe-api-server/Services/TextService.cs
@@ -165,6 +165,7 @@ namespace SQE.API.Server.Services
                                                                                 b.interpretationAttributeId,
                                                                             sequence = b.sequence,
                                                                             attributeValueId = b.attributeValueId,
+                                                                            attributeValueString = b.attributeString,
                                                                             editorId = b
                                                                                 .signInterpretationAttributeAuthor,
                                                                             value = b.value
@@ -261,6 +262,7 @@ namespace SQE.API.Server.Services
                                                     interpretationAttributeId = b.interpretationAttributeId,
                                                     sequence = b.sequence,
                                                     attributeValueId = b.attributeValueId,
+                                                    attributeValueString = b.attributeString,
                                                     editorId = b.signInterpretationAttributeAuthor,
                                                     value = b.value
                                                 }

--- a/sqe-api-test/DbConnectionBaseTest.cs
+++ b/sqe-api-test/DbConnectionBaseTest.cs
@@ -120,8 +120,8 @@ namespace SQE.ApiTest
             // Arrange
             var counter = new Counter { Count = 0 };
             const uint code = 1205;
-            // Currently 175 factorial (_retryCount - 1) - minimum random offset (75 * (_retryCount - 1)), with 1 subtracted
-            const int minExecutionTime = 4374;
+            // See _waitTime method line 126 of DbConnectionBase.cs
+            const int minExecutionTime = 2450;
             var watch = Stopwatch.StartNew();
 
             // Act

--- a/sqe-api-test/EditionTests.cs
+++ b/sqe-api-test/EditionTests.cs
@@ -30,248 +30,231 @@ namespace SQE.ApiTest
         public async Task CanAdminShareEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+            try
             {
-                email = user2.email,
-                mayLock = true,
-                mayWrite = true,
-                isAdmin = true
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayLock = true,
+                    mayWrite = true,
+                    isAdmin = true
+                };
 
-            // Act
-            var add1 = new Post.V1_Editions_EditionId_Editors(newEdition, newPermissions);
-            var (shareResponse, shareMsg, _, _) = await Request.Send(
-                add1,
-                _client,
-                null,
-                auth: true,
-                user1: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-
-            // Assert
-            Assert.True(shareMsg.mayRead);
-            Assert.True(shareMsg.mayWrite);
-            Assert.True(shareMsg.mayLock);
-            Assert.True(shareMsg.isAdmin);
-
-            var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var add1 = new Post.V1_Editions_EditionId_Editors(newEdition, newPermissions);
+                var (_, shareMsg, _, _) = await Request.Send(
+                    add1,
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
-            user1Resp.EnsureSuccessStatusCode();
+                    null,
+                    auth: true
+                );
 
-            var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                // Assert
+                Assert.True(shareMsg.mayRead);
+                Assert.True(shareMsg.mayWrite);
+                Assert.True(shareMsg.mayLock);
+                Assert.True(shareMsg.isAdmin);
+
+                var get1 = new Get.V1_Editions_EditionId(newEdition);
+                var (_, user1Msg, _, _) = await Request.Send(
+                    get1,
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            user2Resp.EnsureSuccessStatusCode();
-            Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
-            Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
-            Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
-            Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
-            Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
-            Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
-            user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+                    null,
+                    auth: true
+                );
+
+                var (_, user2Msg, _, _) = await Request.Send(
+                    get1,
+                    _client,
+                    null,
+                    auth: true,
+                    user1: Request.DefaultUsers.User2
+                );
+                Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
+                Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
+                Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
+                Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
+                Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
+                Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
+                user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
         [Fact]
         public async Task CanChangeEditionSharePermissions()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+
+            try
             {
-                email = user2.email,
-                mayLock = false,
-                mayWrite = false,
-                isAdmin = false
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayLock = false,
+                    mayWrite = false,
+                    isAdmin = false
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var add1 = new Post.V1_Editions_EditionId_Editors(newEdition, newPermissions);
+                var (_, shareMsg, _, _) = await Request.Send(
+                    add1,
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    null,
+                    auth: true
+                );
 
-            // Assert
-            shareResponse.EnsureSuccessStatusCode();
-            Assert.True(shareMsg.mayRead);
-            Assert.False(shareMsg.mayWrite);
-            Assert.False(shareMsg.mayLock);
-            Assert.False(shareMsg.isAdmin);
+                // Assert
+                Assert.True(shareMsg.mayRead);
+                Assert.False(shareMsg.mayWrite);
+                Assert.False(shareMsg.mayLock);
+                Assert.False(shareMsg.isAdmin);
 
-            var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var get1 = new Get.V1_Editions_EditionId(newEdition);
+                var (_, user2Msg, _, _) = await Request.Send(
+                    get1,
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            user2Resp.EnsureSuccessStatusCode();
-            Assert.False(user2Msg.primary.permission.mayWrite);
-            Assert.False(user2Msg.primary.permission.isAdmin);
+                    null,
+                    auth: true,
+                    user1: Request.DefaultUsers.User2
+                );
+                Assert.False(user2Msg.primary.permission.mayWrite);
+                Assert.False(user2Msg.primary.permission.isAdmin);
 
-            // Act
-            newPermissions.mayWrite = true;
-            newPermissions.isAdmin = true;
-            var (share2Response, share2Msg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Put,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                newPermissions.mayWrite = true;
+                newPermissions.isAdmin = true;
+                var add2 = new Put.V1_Editions_EditionId_Editors(newEdition, newPermissions);
+                var (_, share2Msg, _, _) = await Request.Send(
+                    add2,
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    null,
+                    auth: true
+                );
 
-            // Assert
-            share2Response.EnsureSuccessStatusCode();
-            Assert.True(share2Msg.mayRead);
-            Assert.True(share2Msg.mayWrite);
-            Assert.False(share2Msg.mayLock);
-            Assert.True(share2Msg.isAdmin);
+                // Assert
+                Assert.True(share2Msg.mayRead);
+                Assert.True(share2Msg.mayWrite);
+                Assert.False(share2Msg.mayLock);
+                Assert.True(share2Msg.isAdmin);
 
-            var (user2Resp2, user2Msg2) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (_, user2Msg2, _, _) = await Request.Send(
+                    get1,
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            user2Resp2.EnsureSuccessStatusCode();
-            Assert.True(user2Msg2.primary.permission.mayWrite);
-            Assert.True(user2Msg2.primary.permission.isAdmin);
+                    null,
+                    auth: true,
+                    user1: Request.DefaultUsers.User2
+                );
+                Assert.True(user2Msg2.primary.permission.mayWrite);
+                Assert.True(user2Msg2.primary.permission.isAdmin);
 
-            // Act
-            newPermissions.mayLock = true;
-            var (share3Response, share3Msg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Put,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                newPermissions.mayLock = true;
+                var add3 = new Put.V1_Editions_EditionId_Editors(newEdition, newPermissions);
+                var (_, share3Msg, _, _) = await Request.Send(
+                    add3,
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
+                    null,
+                    auth: true,
+                    user1: Request.DefaultUsers.User2
+                );
 
-            // Assert
-            share3Response.EnsureSuccessStatusCode();
-            Assert.True(share3Msg.mayRead);
-            Assert.True(share3Msg.mayWrite);
-            Assert.True(share3Msg.mayLock);
-            Assert.True(share3Msg.isAdmin);
+                // Assert
+                Assert.True(share3Msg.mayRead);
+                Assert.True(share3Msg.mayWrite);
+                Assert.True(share3Msg.mayLock);
+                Assert.True(share3Msg.isAdmin);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
+        // TODO: finish updating tests to use new request objects.
         [Fact]
         public async Task CanDefaultShareEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+
+            try
             {
-                email = user2.email
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Post,
+                    _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
+                    newPermissions,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            // Assert
-            shareResponse.EnsureSuccessStatusCode();
-            Assert.True(shareMsg.mayRead);
-            Assert.False(shareMsg.mayWrite);
-            Assert.False(shareMsg.mayLock);
-            Assert.False(shareMsg.isAdmin);
+                // Assert
+                shareResponse.EnsureSuccessStatusCode();
+                Assert.True(shareMsg.mayRead);
+                Assert.False(shareMsg.mayWrite);
+                Assert.False(shareMsg.mayLock);
+                Assert.False(shareMsg.isAdmin);
 
-            var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
-            user1Resp.EnsureSuccessStatusCode();
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
+                user1Resp.EnsureSuccessStatusCode();
 
-            var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            user2Resp.EnsureSuccessStatusCode();
-            Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
-            Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
-            Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
-            Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
-            Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
-            Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
-            user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User2.email, password = Request.DefaultUsers.User2.password }
+                    )
+                );
+                user2Resp.EnsureSuccessStatusCode();
+                Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
+                Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
+                Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
+                Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
+                Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
+                Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
+                user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
         // TODO: write the rest of the tests.
+        // TODO: finish updating tests to use new request objects.
         [Fact]
         public async Task CanDeleteEditionAsAdmin()
         {
@@ -305,113 +288,139 @@ namespace SQE.ApiTest
             Assert.Empty(editionMatch);
         }
 
+        // TODO: finish updating test to use new request objects.
+        /// <summary>
+        ///     Test copy of copy of edition
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CanDuplicateCopiedEdition()
+        {
+            // ARRANGE
+            var bearerToken = await Request.GetJwtViaHttpAsync(_client);
+            var editionId = await EditionHelpers.CreateCopyOfEdition(_client, name: "first edition");
+            var secondEditionId = await EditionHelpers.CreateCopyOfEdition(_client, editionId, "second edition");
+
+            Assert.True(secondEditionId != null);
+        }
+
+        // TODO: finish updating test to use new request objects.
         [Fact]
         public async Task CanLockableShareEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+
+            try
             {
-                email = user2.email,
-                mayLock = true
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayLock = true
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Post,
+                    _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
+                    newPermissions,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            // Assert
-            shareResponse.EnsureSuccessStatusCode();
-            Assert.True(shareMsg.mayRead);
-            Assert.False(shareMsg.mayWrite);
-            Assert.True(shareMsg.mayLock);
-            Assert.False(shareMsg.isAdmin);
+                // Assert
+                shareResponse.EnsureSuccessStatusCode();
+                Assert.True(shareMsg.mayRead);
+                Assert.False(shareMsg.mayWrite);
+                Assert.True(shareMsg.mayLock);
+                Assert.False(shareMsg.isAdmin);
 
-            var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
-            user1Resp.EnsureSuccessStatusCode();
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
+                user1Resp.EnsureSuccessStatusCode();
 
-            var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            user2Resp.EnsureSuccessStatusCode();
-            Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
-            Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
-            Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
-            Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
-            Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
-            Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
-            user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User2.email, password = Request.DefaultUsers.User2.password }
+                    )
+                );
+                user2Resp.EnsureSuccessStatusCode();
+                Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
+                Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
+                Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
+                Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
+                Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
+                Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
+                user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
+        // TODO: finish updating test to use new request objects.
         [Fact]
         public async Task CanNotAdminWithoutReadShareEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+
+            try
             {
-                email = user2.email,
-                mayRead = false,
-                mayLock = false,
-                mayWrite = false,
-                isAdmin = true
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayRead = false,
+                    mayLock = false,
+                    mayWrite = false,
+                    isAdmin = true
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Post,
+                    _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
+                    newPermissions,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            // Assert
-            Assert.Equal(HttpStatusCode.BadRequest, shareResponse.StatusCode);
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, shareResponse.StatusCode);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
-        // TODO: need sharing capability before this can be tested properly
+        // TODO: finish updating test to use new request objects.
         [Fact]
         public async Task CanNotDeleteEditionWhenAnonymous()
         {
@@ -443,226 +452,251 @@ namespace SQE.ApiTest
             await EditionHelpers.DeleteEdition(_client, editionId);
         }
 
+        // TODO: finish updating test to use new request objects.
         [Fact]
         public async Task CanNotWriteWithoutReadShareEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+
+            try
             {
-                email = user2.email,
-                mayRead = false,
-                mayLock = false,
-                mayWrite = true,
-                isAdmin = false
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayRead = false,
+                    mayLock = false,
+                    mayWrite = true,
+                    isAdmin = false
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Post,
+                    _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
+                    newPermissions,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            // Assert
-            Assert.Equal(HttpStatusCode.BadRequest, shareResponse.StatusCode);
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, shareResponse.StatusCode);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
+        // TODO: finish updating test to use new request objects.
         [Fact]
         public async Task CanProperlyDeleteSharedEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+            var notDeleted = true;
+
+            try
             {
-                email = user2.email,
-                mayLock = true,
-                mayWrite = true,
-                isAdmin = false
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayLock = true,
+                    mayWrite = true,
+                    isAdmin = false
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Post,
+                    _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
+                    newPermissions,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            var (deleteResponse, deleteMsg) = await Request.SendHttpRequestAsync<string, string>(
-                _client,
-                HttpMethod.Delete,
-                "/v1/editions/" + newEdition,
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (deleteResponse, deleteMsg) = await Request.SendHttpRequestAsync<string, string>(
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
+                    HttpMethod.Delete,
+                    "/v1/editions/" + newEdition,
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User2.email, password = Request.DefaultUsers.User2.password }
+                    )
+                );
 
-            // Assert
-            shareResponse.EnsureSuccessStatusCode();
-            Assert.True(shareMsg.mayRead);
-            Assert.True(shareMsg.mayWrite);
-            Assert.True(shareMsg.mayLock);
-            Assert.False(shareMsg.isAdmin);
-            deleteResponse.EnsureSuccessStatusCode();
+                // Assert
+                shareResponse.EnsureSuccessStatusCode();
+                Assert.True(shareMsg.mayRead);
+                Assert.True(shareMsg.mayWrite);
+                Assert.True(shareMsg.mayLock);
+                Assert.False(shareMsg.isAdmin);
+                deleteResponse.EnsureSuccessStatusCode();
 
-            var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
-            user1Resp.EnsureSuccessStatusCode();
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
+                user1Resp.EnsureSuccessStatusCode();
 
-            var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            Assert.Equal(HttpStatusCode.Forbidden, user2Resp.StatusCode);
-            Assert.NotNull(user1Msg);
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User2.email, password = Request.DefaultUsers.User2.password }
+                    )
+                );
+                Assert.Equal(HttpStatusCode.Forbidden, user2Resp.StatusCode);
+                Assert.NotNull(user1Msg);
 
-            // Act (final delete)
-            var (delete2Response, delete2Msg) = await Request.SendHttpRequestAsync<string, string>(
-                _client,
-                HttpMethod.Delete,
-                "/v1/editions/" + newEdition,
-                null,
-                await Request.GetJwtViaHttpAsync(
+                // Act (final delete)
+                var (delete2Response, delete2Msg) = await Request.SendHttpRequestAsync<string, string>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Delete,
+                    "/v1/editions/" + newEdition,
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            // Assert
-            Assert.Equal(HttpStatusCode.BadRequest, delete2Response.StatusCode); // Should fail for last admin
-                                                                                 // Kill the edition for real
-            await EditionHelpers.DeleteEdition(
-                _client,
-                newEdition,
-                true,
-                true,
-                new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var (user1Resp2, user1Msg2) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, delete2Response.StatusCode); // Should fail for last admin
+                                                                                     // Kill the edition for real
+                await EditionHelpers.DeleteEdition(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
-            user1Resp2.EnsureSuccessStatusCode();
-            Assert.Null(user1Msg2);
+                    newEdition,
+                    true,
+                    true,
+                    new Request.UserAuthDetails
+                    { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                );
+                var (user1Resp2, user1Msg2) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
+                    _client,
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
+                if (user1Resp2.StatusCode == HttpStatusCode.NoContent)
+                    notDeleted = false;
+                user1Resp2.EnsureSuccessStatusCode();
+                Assert.Null(user1Msg2);
+            }
+            finally
+            {
+                // Cleanup
+                if (notDeleted)
+                    await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
+
 
             //Todo: maybe run a database check here to ensure that all references to newEdition have been removed from all *_owner tables
         }
 
+        // TODO: finish updating test to use new request objects.
         [Fact]
         public async Task CanWriteShareEdition()
         {
             // Arrange
-            const string user1Pwd = "pwd1";
-            var user1 = await UserHelpers.CreateRandomUserAsync(_client, user1Pwd);
-            const string user2Pwd = "pwd2";
-            var user2 = await UserHelpers.CreateRandomUserAsync(_client, user2Pwd);
-            var newEdition = await EditionHelpers.CreateCopyOfEdition(
-                _client,
-                userAuthDetails: new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-            );
-            var newPermissions = new EditorRightsDTO
+            var newEdition = await EditionHelpers.CreateCopyOfEdition(_client);
+            try
             {
-                email = user2.email,
-                mayWrite = true
-            };
+                var newPermissions = new EditorRightsDTO
+                {
+                    email = Request.DefaultUsers.User2.email,
+                    mayWrite = true
+                };
 
-            // Act
-            var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
-                _client,
-                HttpMethod.Post,
-                _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
-                newPermissions,
-                await Request.GetJwtViaHttpAsync(
+                // Act
+                var (shareResponse, shareMsg) = await Request.SendHttpRequestAsync<EditorRightsDTO, EditorRightsDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
+                    HttpMethod.Post,
+                    _addEditionEditor.Replace("$EditionId", newEdition.ToString()),
+                    newPermissions,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
 
-            // Assert
-            shareResponse.EnsureSuccessStatusCode();
-            Assert.True(shareMsg.mayRead);
-            Assert.True(shareMsg.mayWrite);
-            Assert.False(shareMsg.mayLock);
-            Assert.False(shareMsg.isAdmin);
+                // Assert
+                shareResponse.EnsureSuccessStatusCode();
+                Assert.True(shareMsg.mayRead);
+                Assert.True(shareMsg.mayWrite);
+                Assert.False(shareMsg.mayLock);
+                Assert.False(shareMsg.isAdmin);
 
-            var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user1Resp, user1Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user1.email, password = user1Pwd }
-                )
-            );
-            user1Resp.EnsureSuccessStatusCode();
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User1.email, password = Request.DefaultUsers.User1.password }
+                    )
+                );
+                user1Resp.EnsureSuccessStatusCode();
 
-            var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                $"/v1/editions/{newEdition}",
-                null,
-                await Request.GetJwtViaHttpAsync(
+                var (user2Resp, user2Msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
                     _client,
-                    new Request.UserAuthDetails { email = user2.email, password = user2Pwd }
-                )
-            );
-            user2Resp.EnsureSuccessStatusCode();
-            Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
-            Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
-            Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
-            Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
-            Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
-            Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
-            user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+                    HttpMethod.Get,
+                    $"/v1/editions/{newEdition}",
+                    null,
+                    await Request.GetJwtViaHttpAsync(
+                        _client,
+                        new Request.UserAuthDetails
+                        { email = Request.DefaultUsers.User2.email, password = Request.DefaultUsers.User2.password }
+                    )
+                );
+                user2Resp.EnsureSuccessStatusCode();
+                Assert.Equal(user1Msg.primary.id, user2Msg.primary.id);
+                Assert.Equal(user1Msg.primary.copyright, user2Msg.primary.copyright);
+                Assert.Equal(user1Msg.primary.isPublic, user2Msg.primary.isPublic);
+                Assert.Equal(user1Msg.primary.locked, user2Msg.primary.locked);
+                Assert.Equal(user1Msg.primary.name, user2Msg.primary.name);
+                Assert.Equal(user1Msg.primary.thumbnailUrl, user2Msg.primary.thumbnailUrl);
+                user1Msg.primary.lastEdit.ShouldDeepEqual(user2Msg.primary.lastEdit);
+            }
+            finally
+            {
+                // Cleanup
+                await EditionHelpers.DeleteEdition(_client, newEdition);
+            }
         }
 
+        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Test copying an edition
         /// </summary>
@@ -716,6 +750,7 @@ namespace SQE.ApiTest
             Assert.True(msg.id != 1);
         }
 
+        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Check if we can get editions when unauthenticated
         /// </summary>
@@ -737,6 +772,7 @@ namespace SQE.ApiTest
             Assert.True(msg.editions.Count > 0);
         }
 
+        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Check if we can get editions when unauthenticated
         /// </summary>
@@ -762,6 +798,7 @@ namespace SQE.ApiTest
             Assert.NotNull(msg.primary.name);
         }
 
+        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Check that we get private editions when authenticated, and don't get them when unauthenticated.
         /// </summary>
@@ -812,6 +849,7 @@ namespace SQE.ApiTest
             Assert.DoesNotContain(msg.editions.SelectMany(x => x), x => x.id == editionId);
         }
 
+        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Check if we protect against disallowed unauthenticated requests
         /// </summary>
@@ -846,6 +884,7 @@ namespace SQE.ApiTest
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
+        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Test updating an edition
         /// </summary>
@@ -888,22 +927,5 @@ namespace SQE.ApiTest
             Assert.True(msg2.name == name);
             Assert.True(msg2.id == editionId);
         }
-
-		/// <summary>
-		/// Test copy of copy of edition
-		/// </summary>
-		/// <returns></returns>
-		[Fact]
-		public async Task DuplicateCopy()
-		{
-			// ARRANGE
-			var bearerToken = await Request.GetJwtViaHttpAsync(_client);
-			var editionId = await EditionHelpers.CreateCopyOfEdition(_client, name: "first edition");
-			var secondEditionId = await EditionHelpers.CreateCopyOfEdition(_client, editionId, "second edition");
-
-			Assert.True(secondEditionId != null);
-
-		}
-
-	}
+    }
 }

--- a/sqe-api-test/EditionTests.cs
+++ b/sqe-api-test/EditionTests.cs
@@ -888,5 +888,22 @@ namespace SQE.ApiTest
             Assert.True(msg2.name == name);
             Assert.True(msg2.id == editionId);
         }
-    }
+
+		/// <summary>
+		/// Test copy of copy of edition
+		/// </summary>
+		/// <returns></returns>
+		[Fact]
+		public async Task DuplicateCopy()
+		{
+			// ARRANGE
+			var bearerToken = await Request.GetJwtViaHttpAsync(_client);
+			var editionId = await EditionHelpers.CreateCopyOfEdition(_client, name: "first edition");
+			var secondEditionId = await EditionHelpers.CreateCopyOfEdition(_client, editionId, "second edition");
+
+			Assert.True(secondEditionId != null);
+
+		}
+
+	}
 }

--- a/sqe-api-test/TextTest.cs
+++ b/sqe-api-test/TextTest.cs
@@ -163,6 +163,7 @@ namespace SQE.ApiTest
                 (uint)0,
                 msg.signs.First().signInterpretations.First().attributes.First().interpretationAttributeId
             );
+            Assert.NotNull(msg.signs.First().signInterpretations.First().attributes.First().attributeValueString);
 
             var editorIds = new List<uint> { msg.editorId };
             foreach (var sign in msg.signs)
@@ -220,6 +221,14 @@ namespace SQE.ApiTest
                     .signInterpretations.First()
                     .attributes.First()
                     .interpretationAttributeId
+            );
+            Assert.NotNull(
+                msg.textFragments.First()
+                    .lines.First()
+                    .signs.First()
+                    .signInterpretations.First()
+                    .attributes.First()
+                    .attributeValueString
             );
 
             var editorIds = new List<uint> { msg.editorId };

--- a/sqe-database-access/DbConnectionBase.cs
+++ b/sqe-database-access/DbConnectionBase.cs
@@ -71,7 +71,7 @@ namespace SQE.DatabaseAccess
     public static class DatabaseCommunicationRetryPolicy
     {
         // There is a +-75 ms randomness added to the retry pause.
-        // The total delay will be somewhere between 4375 and 5425 ms.
+        // The total delay will be somewhere between 2450 and 7350 ms.
         private const int RetryCount = 7;
         private const int WaitBetweenRetriesInMilliseconds = 175;
 
@@ -125,7 +125,8 @@ namespace SQE.DatabaseAccess
         /// <returns></returns>
         private static int _waitTime(int retryCount)
         {
-            return retryCount * WaitBetweenRetriesInMilliseconds + _random.Next(-75, 75);
+            var waitTime = retryCount * WaitBetweenRetriesInMilliseconds;
+            return waitTime + _random.Next(-1 * waitTime / 2, waitTime / 2);
         }
 
         public static void ExecuteRetry(Action operation)
@@ -232,7 +233,8 @@ namespace SQE.DatabaseAccess
         /// <returns></returns>
         private int _waitTime(int retryCount)
         {
-            return retryCount * WaitBetweenRetriesInMilliseconds + _random.Next(-100, 100);
+            var waitTime = retryCount * WaitBetweenRetriesInMilliseconds;
+            return waitTime + _random.Next(-1 * waitTime / 2, waitTime / 2);
         }
 
         public void ExecuteRetryWithCircuitBreaker(Action operation)

--- a/sqe-database-access/EditionRepository.cs
+++ b/sqe-database-access/EditionRepository.cs
@@ -163,6 +163,17 @@ namespace SQE.DatabaseAccess
                 }
             }
 
+            // Right now we create all the new rows for the new edition
+            // in one transaction. The benefit of this is that if it fails
+            // for some reason, nothing is committed. The downside is that
+            // it is a long-running process, that touches many rows (thus
+            // locking them up). If we really do run into performance problems,
+            // consider writing each data table in its own transaction,
+            // and be prepared to DELETE all INSERTS in the case an unrecoverable
+            // failure is encountered. The danger of doing that is that you might
+            // end up with "orphaned" INSERTS in the case that the API crashes
+            // in the middle of such a procedure. Then you would need to periodically
+            // check the owner tables for these failed writes, which could be difficult.
             return await DatabaseCommunicationRetryPolicy.ExecuteRetry(
                 async () =>
                 {

--- a/sqe-database-access/Helpers/DatabaseWriter.cs
+++ b/sqe-database-access/Helpers/DatabaseWriter.cs
@@ -264,8 +264,10 @@ namespace SQE.DatabaseAccess.Helpers
         private static async Task<uint> InsertOwnedTableAsync(IDbConnection connection, MutationRequest mutationRequest)
         {
             // Format query
-            var hasNulls = (mutationRequest.Parameters.ParameterNames.Any(x =>
-                ((SqlMapper.IParameterLookup)mutationRequest.Parameters)[x] == null));
+            var hasNulls = mutationRequest.Parameters.ParameterNames.Any(
+                x =>
+                    ((SqlMapper.IParameterLookup)mutationRequest.Parameters)[x] == null
+            );
             var query = OwnedTableInsertQuery.GetQuery(hasNulls);
             query = query.Replace("$TableName", mutationRequest.TableName);
             query = query.Replace("$Columns", string.Join(",", mutationRequest.ColumnNames));

--- a/sqe-database-access/Models/InterpretationAttribute.cs
+++ b/sqe-database-access/Models/InterpretationAttribute.cs
@@ -5,7 +5,14 @@ namespace SQE.DatabaseAccess.Models
         public uint interpretationAttributeId { get; set; }
         public byte sequence { get; set; }
         public uint attributeValueId { get; set; }
+        public string attributeString { get; set; }
         public uint signInterpretationAttributeAuthor { get; set; }
         public float value { get; set; }
+    }
+
+    public class AttributeDefinition
+    {
+        public uint attributeValueId { get; set; }
+        public string attributeString { get; set; }
     }
 }

--- a/sqe-database-access/Queries/Edition.cs
+++ b/sqe-database-access/Queries/Edition.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SQE.DatabaseAccess.Queries
 {
@@ -234,6 +236,33 @@ WHERE edition_editor.edition_id = @EditionId
         }
     }
 
+    internal static class GetOwnerTableDataForQuery
+    {
+        // You must add a parameter `@EditionId`.
+        public static string GetQuery(string tableName, string tableIdColumn)
+        {
+            return $@"SELECT {tableIdColumn} 
+            FROM {tableName} 
+            WHERE edition_id = @EditionId";
+        }
+    }
+
+    internal static class WriteOwnerTableData
+    {
+        public static string GetQuery(string tableName,
+            string tableIdColumn,
+            uint editionId,
+            uint editionEditorId,
+            List<uint> dataIds)
+        {
+            return $@"INSERT INTO {tableName} (edition_id, edition_editor_id, {tableIdColumn})
+            VALUES {string.Join(
+                    ",",
+                    dataIds.Select(x => $"({editionId},{editionEditorId},{x.ToString()})"))
+                }";
+        }
+    }
+
     internal static class UpdateEditionLegalDetailsQuery
     {
         // You must add the parameter `@EditionId` and `@Collaborators` to use this, the parameter `@CopyrightHolder` is optional.
@@ -263,5 +292,23 @@ WHERE $Table.edition_id = @EditionId AND edition_editor.is_admin = 1
         {
             return _sql.Replace("$Table", table);
         }
+    }
+
+    internal static class LockEditionQuery
+    {
+        internal const string GetQuery = @"
+UPDATE edition
+SET locked = 1
+WHERE edition_id = @EditionId
+";
+    }
+
+    internal static class UnlockEditionQuery
+    {
+        internal const string GetQuery = @"
+UPDATE edition
+SET locked = 0
+WHERE edition_id = @EditionId
+";
     }
 }

--- a/sqe-database-access/Queries/Text.cs
+++ b/sqe-database-access/Queries/Text.cs
@@ -244,6 +244,21 @@ WHERE text_fragment_data.text_fragment_id = @TextFragmentId
    AND (edition.public = 1 OR edition_editor.user_id = @UserId)";
     }
 
+    internal static class TextFragmentAttributes
+    {
+        public const string GetQuery = @"
+SELECT DISTINCT attribute_value.attribute_value_id AS attributeValueId, REGEXP_REPLACE(LOWER(CONCAT(attribute.name, '-', attribute_value.string_value)), '[ _]', '-') AS attributeString
+FROM attribute_value
+JOIN attribute_value_owner 
+	ON attribute_value_owner.attribute_value_id = attribute_value.attribute_value_id 
+	AND attribute_value_owner.edition_id = @EditionId
+JOIN attribute USING(attribute_id)
+JOIN attribute_owner 
+	ON attribute_owner.attribute_id = attribute.attribute_id 
+	AND attribute_owner.edition_id = @EditionId
+";
+    }
+
     internal static class CreateTextFragment
     {
         public const string GetQuery = @"

--- a/sqe-dto/Sign.cs
+++ b/sqe-dto/Sign.cs
@@ -27,6 +27,7 @@ namespace SQE.API.DTO
         public uint interpretationAttributeId { get; set; }
         public byte sequence { get; set; }
         public uint attributeValueId { get; set; }
+        public string attributeValueString { get; set; }
         public uint editorId { get; set; }
         public float value { get; set; }
     }

--- a/sqe-dto/TextFragment.cs
+++ b/sqe-dto/TextFragment.cs
@@ -23,15 +23,21 @@ namespace SQE.API.DTO
     public class ArtefactTextFragmentMatchDTO : TextFragmentDataDTO
     {
         /// <summary>
-        /// This DTO contains the data of a text fragment that has been requested via
-        /// artefact id.
+        ///     This DTO contains the data of a text fragment that has been requested via
+        ///     artefact id.
         /// </summary>
         /// <param name="id">Id of the text fragment</param>
         /// <param name="name">Name of the text fragment</param>
         /// <param name="editorId">Id of the editor who sefined the text fragment</param>
-        /// <param name="suggested">Whether this text fragment was suggest by the system (true)
-        /// or is a definite match (false)</param>
-        public ArtefactTextFragmentMatchDTO(uint id, string name, uint editorId, bool suggested) : base(id, name, editorId)
+        /// <param name="suggested">
+        ///     Whether this text fragment was suggest by the system (true)
+        ///     or is a definite match (false)
+        /// </param>
+        public ArtefactTextFragmentMatchDTO(uint id, string name, uint editorId, bool suggested) : base(
+            id,
+            name,
+            editorId
+        )
         {
             this.suggested = suggested;
         }

--- a/ts-dtos/sqe-dtos.ts
+++ b/ts-dtos/sqe-dtos.ts
@@ -208,6 +208,7 @@ export interface InterpretationAttributeDTO {
     interpretationAttributeId: number;
     sequence: number;
     attributeValueId: number;
+    attributeValueString: string;
     editorId: number;
     value: number;
 }


### PR DESCRIPTION
The copy duplicated edition test is now passing.  The copy edition endpoint no longer needs the edition to be locked.  I have added a bit more randomization to the retry policy in hopes to further minimize deadlock.

Check the InterpretationAttributeDTO for the new attributeValueString, which you can use for CSS class selectors.

I cleaned up some more of the user tests