### PR TITLE
fixed error in parsing imaged object ids

### DIFF
--- a/sqe-api-server/Services/ImageService.cs
+++ b/sqe-api-server/Services/ImageService.cs
@@ -56,6 +56,7 @@ namespace SQE.API.Server.Services
 
         public async Task<List<ImagedObjectTextFragmentMatchDTO>> GetImageTextFragmentsAsync(string imagedObjectId)
         {
+            imagedObjectId = System.Web.HttpUtility.UrlDecode(imagedObjectId);
             var textFragments = await _imageRepo.GetImageTextFragmentsAsync(imagedObjectId);
             return textFragments.Select(x => new ImagedObjectTextFragmentMatchDTO(
                 x.EditionId, x.ManuscriptName, x.TextFragmentId, x.TextFragmentName, x.Side == 0 ? "recto" : "verso")

--- a/sqe-api-server/Services/ImagedObjectService.cs
+++ b/sqe-api-server/Services/ImagedObjectService.cs
@@ -119,6 +119,7 @@ namespace SQE.API.Server.Services
             string imagedObjectId,
             List<string> optional = null)
         {
+            imagedObjectId = System.Web.HttpUtility.UrlDecode(imagedObjectId);
             ParseOptionals(optional, out var artefacts, out var masks);
             var result =
                 (await GetImagedObjectsAsync(editionUser)).imagedObjects.First(x => x.id == imagedObjectId);

--- a/sqe-api-test/ApiRequests/ApiRequests.cs
+++ b/sqe-api-test/ApiRequests/ApiRequests.cs
@@ -216,9 +216,9 @@ namespace SQE.ApiTest.ApiRequests
     /// </summary>
     /// <typeparam name="Tinput">The type of the request payload</typeparam>
     /// <typeparam name="Toutput">The API endpoint return type</typeparam>
-    public class ImagedObjectRequestObject<Tinput, Toutput, TListener> : EditionRequestObject<Tinput, Toutput, TListener>
+    public class EditionImagedObjectRequestObject<Tinput, Toutput, TListener> : EditionRequestObject<Tinput, Toutput, TListener>
     {
-        public readonly uint imagedObjectId;
+        public readonly string imagedObjectId;
 
         /// <summary>
         ///     Provides an ImagedObjectRequestObject for all API requests made on an edition
@@ -226,8 +226,8 @@ namespace SQE.ApiTest.ApiRequests
         /// <param name="editionId">The id of the edition to perform the request on</param>
         /// <param name="imagedObjectId">The id of the imaged object to perform the request on</param>
         /// <param name="payload">Payload to be sent to the API endpoint</param>
-        public ImagedObjectRequestObject(uint editionId,
-            uint imagedObjectId,
+        public EditionImagedObjectRequestObject(uint editionId,
+            string imagedObjectId,
             List<string> optional = null,
             Tinput payload = default) : base(editionId, optional, payload)
         {
@@ -381,6 +381,37 @@ namespace SQE.ApiTest.ApiRequests
             return signalR => payload == null
                 ? signalR.InvokeAsync<T>(SignalrRequestString(), editionId, roiId)
                 : signalR.InvokeAsync<T>(SignalrRequestString(), editionId, roiId, payload);
+        }
+    }
+
+    /// <summary>
+    ///     Subclass of EditionRequestObject for all requests made on an imaged object
+    /// </summary>
+    /// <typeparam name="Tinput">The type of the request payload</typeparam>
+    /// <typeparam name="Toutput">The API endpoint return type</typeparam>
+    /// <typeparam name="TListener">The API endpoint listener return type</typeparam>
+    public class ImagedObjectRequestObject<Tinput, Toutput, TListener> : RequestObject<Tinput, Toutput, TListener>
+    {
+        public readonly string imagedObjectId;
+
+        /// <summary>
+        ///     Provides an ImagedObjectRequestObject for all API requests made on an imaged object
+        /// </summary>
+        /// <param name="imagedObjectId">The id of the imaged object to perform the request on</param>
+        public ImagedObjectRequestObject(string imagedObjectId) : base(default(Tinput))
+        {
+            this.imagedObjectId = imagedObjectId;
+        }
+
+        protected override string HttpPath()
+        {
+            return base.HttpPath().Replace("/imaged-object-id", $"/{imagedObjectId}");
+        }
+
+        public override Func<HubConnection, Task<T>> SignalrRequest<T>()
+        {
+            return signalR =>
+                signalR.InvokeAsync<T>(SignalrRequestString(), imagedObjectId, payload);
         }
     }
 

--- a/sqe-api-test/ApiRequests/ImagedObjectRequests.cs
+++ b/sqe-api-test/ApiRequests/ImagedObjectRequests.cs
@@ -12,11 +12,19 @@ namespace SQE.ApiTest.ApiRequests
             }
         }
 
+        public class V1_ImagedObjects_ImagedObjectId_TextFragments
+            : ImagedObjectRequestObject<EmptyInput, List<ImagedObjectTextFragmentMatchDTO>, EmptyOutput>
+        {
+            public V1_ImagedObjects_ImagedObjectId_TextFragments(string imagedObjectId) : base(imagedObjectId)
+            {
+            }
+        }
+
         public class V1_Editions_EditionId_ImagedObjects
             : EditionRequestObject<EmptyInput, ImagedObjectListDTO, EmptyOutput>
         {
             public V1_Editions_EditionId_ImagedObjects(uint editionId,
-                uint imagedObjectId,
+                string imagedObjectId,
                 List<string> optional = null)
                 : base(editionId, optional)
             {
@@ -24,10 +32,10 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_ImagedObjects_ImagedObjectId
-            : ImagedObjectRequestObject<EmptyInput, ImagedObjectDTO, EmptyOutput>
+            : EditionImagedObjectRequestObject<EmptyInput, ImagedObjectDTO, EmptyOutput>
         {
             public V1_Editions_EditionId_ImagedObjects_ImagedObjectId(uint editionId,
-                uint imagedObjectId,
+                string imagedObjectId,
                 List<string> optional = null)
                 : base(editionId, imagedObjectId, optional)
             {

--- a/sqe-api-test/ImagedObjectTest.cs
+++ b/sqe-api-test/ImagedObjectTest.cs
@@ -1,10 +1,13 @@
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web;
 using Dapper;
 using Microsoft.AspNetCore.Mvc.Testing;
+using NetTopologySuite.Geometries.Utilities;
 using SQE.API.DTO;
 using SQE.API.Server;
+using SQE.ApiTest.ApiRequests;
 using SQE.ApiTest.Helpers;
 using Xunit;
 
@@ -262,6 +265,29 @@ LIMIT 50";
                         }
 
             Assert.True(foundArtefactWithMask);
+        }
+
+        /// <summary>
+        /// Can recognize imaged object ids with url encoded values
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CanDecodeImagedObjectIdWithUrlEncodedValue()
+        {
+            // Note: the dotnet HTTP Request system automatically escapes the URL's we submit,
+            // so we need to encode the URL first (remember this!!!).
+            var id = HttpUtility.UrlEncode("IAA-275%2F1-1");
+            var textFragRequest = new Get.V1_ImagedObjects_ImagedObjectId_TextFragments(id);
+
+            var (response, msg, _, _) = await Request.Send(
+                textFragRequest,
+                _client);
+
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(1, msg.Count);
+            Assert.Equal("4Q7", msg.First().manuscriptName);
+            Assert.Equal("frg. 1", msg.First().textFragmentName);
+            Assert.Equal((uint)9423, msg.First().textFragmentId);
         }
     }
 }


### PR DESCRIPTION
I found a small error in the imaged object related endpoints.  Sometimes an imaged object id could contain a `/`, like `IAA-275/1-1`, which must be escaped when used in a path like `/v1/imaged-objects/IAA-275%2F1-1/text-fragments`. The API was not decoding such ids (e.g., back to `IAA-275/1-1`) before making the request to the database.  This patch has added that functionality. An integration test for such cases has now been added as well.