### PR TITLE
Attributes patch

### DIFF
--- a/data-to-sqe/qwb-to-sqe/QwbSide/QWBWord.cs
+++ b/data-to-sqe/qwb-to-sqe/QwbSide/QWBWord.cs
@@ -70,7 +70,6 @@ namespace qwb_to_sqe
                             break;
                         case '\u05BE': // Single destroyed sign
                             if (_lastAttributeIs(currSign, Destroyed) == false) currSign = _newSign(' ', Destroyed, 0);
-                            _expandLastNumericValue(currSign, Destroyed);
                             break;
                         case '_': // Vacat
                             if (_lastAttributeIs(currSign, Vacat) == false)
@@ -79,7 +78,6 @@ namespace qwb_to_sqe
                                 _handleNewSign(currSign);
                             }
 
-                            _expandLastNumericValue(currSign, Vacat);
                             break;
                         case '-': // Destroyed area
                             if (_lastAttributeIs(currSign, Destroyed) == false)
@@ -88,7 +86,6 @@ namespace qwb_to_sqe
                                 _handleNewSign(currSign);
                             }
 
-                            _expandLastNumericValue(currSign, Destroyed, 3);
                             break;
                         case '^': // Switch for superscript
                             _switchAttribute(SuperScript);
@@ -209,7 +206,6 @@ namespace qwb_to_sqe
             sign?.SignInterpretations.Last().Attributes.Add(new SignInterpretationAttributeData
             {
                 AttributeValueId = attributeId,
-                NumericValue = numericValue
             });
         }
 
@@ -217,12 +213,6 @@ namespace qwb_to_sqe
         {
             return sign?.SignInterpretations.Last().Attributes.Exists(data => data.AttributeValueId == attributeId) ??
                    false;
-        }
-
-        private void _expandLastNumericValue(SignData sign, uint attributeValueId, uint by = 1)
-        {
-            sign.SignInterpretations.Last().Attributes.Find(attr =>
-                attr.AttributeValueId == attributeValueId).NumericValue += by;
         }
     }
 }

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.20.3
+        image: qumranica/sqe-database:0.21.0
         container_name: SQE_Database
         environment:
             ## These must be updated when used in production

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.20.3
+        image: qumranica/sqe-database:0.21.0
         container_name: SQE_Database
         # These environment variables match the default db connection settings for the project.
         environment:

--- a/sqe-api-server/Serialization/SignInterpretationConversion.cs
+++ b/sqe-api-server/Serialization/SignInterpretationConversion.cs
@@ -17,7 +17,11 @@ namespace SQE.API.Server.Serialization
                         attr.AttributeName,
                         attr.AttributeDescription,
                         attr.AttributeCreator,
-                        attr.AttributeEditor),
+                        attr.AttributeEditor,
+                        attr.Editable,
+                        attr.Removable,
+                        attr.Repeatable,
+                        attr.BatchEditable),
                     attr => new AttributeValueDTO()
                     {
                         id = attr.AttributeValueId,
@@ -35,6 +39,10 @@ namespace SQE.API.Server.Serialization
                         creatorId = attrId.AttributeCreator,
                         editorId = attrId.AttributeEditor,
                         values = attrValues.ToArray(),
+                        editable = attrId.Editable,
+                        removable = attrId.Removable,
+                        repeatable = attrId.Repeatable,
+                        batchEditable = attrId.BatchEditable,
                     }).ToArray(),
             };
         }
@@ -50,7 +58,6 @@ namespace SQE.API.Server.Serialization
                 editorId = sia.SignInterpretationAttributeEditorId ?? 0,
                 interpretationAttributeId = sia.SignInterpretationAttributeId ?? 0,
                 sequence = sia.Sequence ?? 0,
-                value = sia.NumericValue ?? 0,
                 commentary = comms.Where(y =>
                         y.AttributeId.HasValue && y.AttributeId.Value == sia.AttributeId.Value)
                     .Select(y => y.ToDTO())
@@ -150,7 +157,6 @@ namespace SQE.API.Server.Serialization
                 AttributeId = x.attributeId,
                 AttributeValueId = x.attributeValueId,
                 Sequence = x.sequence,
-                NumericValue = x.value
             }).ToList();
         }
 

--- a/sqe-api-server/Serialization/SignInterpretationConversion.cs
+++ b/sqe-api-server/Serialization/SignInterpretationConversion.cs
@@ -52,6 +52,7 @@ namespace SQE.API.Server.Serialization
             return new InterpretationAttributeDTO()
             {
                 attributeId = sia.AttributeId ?? 0,
+                attributeString = sia.AttributeString,
                 attributeValueId = sia.AttributeValueId ?? 0,
                 attributeValueString = sia.AttributeValueString,
                 creatorId = sia.SignInterpretationAttributeCreatorId ?? 0,

--- a/sqe-api-server/Services/SignInterpretationService.cs
+++ b/sqe-api-server/Services/SignInterpretationService.cs
@@ -107,12 +107,16 @@ namespace SQE.API.Server.Services
                 user,
                 newAttribute.attributeName,
                 newAttribute.description,
-                newAttribute.values.Select(x => new SignInterpretationAttributeValueInput()
-                {
-                    AttributeStringValue = x.value,
-                    AttributeStringValueDescription = x.description,
-                    Css = x.cssDirectives,
-                }));
+                newAttribute.editable,
+                newAttribute.removable,
+                newAttribute.repeatable,
+                newAttribute.batchEditable,
+            newAttribute.values.Select(x => new SignInterpretationAttributeValueInput()
+            {
+                AttributeStringValue = x.value,
+                AttributeStringValueDescription = x.description,
+                Css = x.cssDirectives,
+            }));
 
             var createdAttribute = (await _attributeRepository.GetEditionAttributeAsync(user, newAttributeId)).ToDTO().attributes.FirstOrDefault();
 
@@ -131,6 +135,10 @@ namespace SQE.API.Server.Services
                 attributeId,
                 null,
                 null,
+                updatedAttribute.editable,
+                updatedAttribute.removable,
+                updatedAttribute.repeatable,
+                updatedAttribute.batchEditable,
                 updatedAttribute.createValues.Select(x => x.FromDTO()),
                 updatedAttribute.updateValues.Select(x => x.FromDTO()),
                 updatedAttribute.deleteValues);
@@ -275,7 +283,6 @@ namespace SQE.API.Server.Services
             var createAttribute = new SignInterpretationAttributeData()
             {
                 AttributeValueId = attribute.attributeValueId,
-                NumericValue = attribute.value,
                 Sequence = attribute.sequence,
             };
             await _attributeRepository.CreateSignInterpretationAttributesAsync(user, signInterpretationId, createAttribute);
@@ -304,9 +311,9 @@ namespace SQE.API.Server.Services
             uint signInterpretationId, uint attributeValueId, InterpretationAttributeCreateDTO attribute,
             string clientId = null)
         {
-            if (attribute.sequence.HasValue || attribute.value.HasValue)
+            if (attribute.sequence.HasValue)
                 await _attributeRepository.UpdateAttributeForSignInterpretationAsync(user, signInterpretationId,
-                    attributeValueId, attribute.sequence, attribute.value);
+                    attributeValueId, attribute.sequence);
 
             if (!string.IsNullOrEmpty(attribute.commentary))
                 await _commentaryRepository.CreateOrUpdateCommentaryAsync(user, signInterpretationId, attributeValueId,

--- a/sqe-api-server/Services/TextService.cs
+++ b/sqe-api-server/Services/TextService.cs
@@ -231,6 +231,7 @@ namespace SQE.API.Server.Services
                                                                             sequence = b.Sequence.GetValueOrDefault(),
                                                                             attributeId = b.AttributeId
                                                                                 .GetValueOrDefault(),
+                                                                            attributeString = b.AttributeString,
                                                                             attributeValueId =
                                                                                 b.AttributeValueId.GetValueOrDefault(),
                                                                             attributeValueString = b.AttributeValueString,
@@ -338,6 +339,7 @@ namespace SQE.API.Server.Services
                                                     interpretationAttributeId =
                                                         b.SignInterpretationAttributeId.GetValueOrDefault(),
                                                     sequence = b.Sequence.GetValueOrDefault(),
+                                                    attributeString = b.AttributeString,
                                                     attributeValueId = b.AttributeValueId.GetValueOrDefault(),
                                                     attributeValueString = b.AttributeValueString,
                                                     editorId = b.SignInterpretationAttributeEditorId.GetValueOrDefault(),

--- a/sqe-api-server/Services/TextService.cs
+++ b/sqe-api-server/Services/TextService.cs
@@ -239,7 +239,6 @@ namespace SQE.API.Server.Services
                                                                                 .GetValueOrDefault(),
                                                                             creatorId = b.SignInterpretationAttributeCreatorId
                                                                                 .GetValueOrDefault(),
-                                                                            value = b.NumericValue.GetValueOrDefault()
                                                                         }
                                                                     )
                                                                     .ToArray(),
@@ -342,7 +341,6 @@ namespace SQE.API.Server.Services
                                                     attributeValueId = b.AttributeValueId.GetValueOrDefault(),
                                                     attributeValueString = b.AttributeValueString,
                                                     editorId = b.SignInterpretationAttributeEditorId.GetValueOrDefault(),
-                                                    value = b.NumericValue.GetValueOrDefault()
                                                 }
                                             )
                                             .ToArray(),

--- a/sqe-api-test/SignInterpretationTests.cs
+++ b/sqe-api-test/SignInterpretationTests.cs
@@ -158,7 +158,6 @@ namespace SQE.ApiTest
                 Assert.Null(responseAttr.commentary);
                 Assert.True(responseAttr.sequence.HasValue);
                 Assert.Equal(0, responseAttr.sequence.Value);
-                Assert.Equal(0, responseAttr.value);
                 Assert.NotEqual<uint>(0, responseAttr.creatorId);
                 Assert.NotEqual<uint>(0, responseAttr.editorId);
                 Assert.NotEqual<uint>(0, responseAttr.attributeId);
@@ -230,6 +229,11 @@ namespace SQE.ApiTest
                     .First(x => x.textFragmentId == textFragment.textFragmentId)
                     .lines.First(x => x.lineId == line.lineId).signs;
 
+                // Sort the lists of sign attributes (otherwise ShouldDeepEqual will possibly fail)
+                signs.First().signInterpretations.First().attributes = signs.First().signInterpretations.First()
+                    .attributes.OrderBy(x => x.attributeValueId).ToArray();
+                newSignInterpretationRequest.HttpResponseObject.signInterpretations.First().attributes = newSignInterpretationRequest.HttpResponseObject.signInterpretations.First().attributes
+                    .OrderBy(x => x.attributeValueId).ToArray();
                 // Make sure the two updated/new sign interpretations are in the stream
                 signs.First().signInterpretations.First()
                     .ShouldDeepEqual(newSignInterpretationRequest.HttpResponseObject.signInterpretations.First());
@@ -257,7 +261,6 @@ namespace SQE.ApiTest
                     Assert.Equal(attrMatch.attributeValueString, attr.attributeValueString);
                     Assert.Equal(attrMatch.interpretationAttributeId, attr.interpretationAttributeId);
                     Assert.Equal(attrMatch.sequence, attr.sequence);
-                    Assert.Equal(attrMatch.value, attr.value);
                     Assert.Equal(attrMatch.attributeId, attr.attributeId);
                 }
 
@@ -555,7 +558,6 @@ namespace SQE.ApiTest
                 Assert.Null(responseAttr.commentary);
                 Assert.True(responseAttr.sequence.HasValue);
                 Assert.Equal(0, responseAttr.sequence.Value);
-                Assert.Equal(0, responseAttr.value);
                 Assert.NotEqual<uint>(0, responseAttr.creatorId);
                 Assert.NotEqual<uint>(0, responseAttr.editorId);
                 Assert.NotEqual<uint>(0, responseAttr.attributeId);
@@ -819,7 +821,6 @@ namespace SQE.ApiTest
                 Assert.Null(responseAttr.commentary);
                 Assert.True(responseAttr.sequence.HasValue);
                 Assert.Equal(0, responseAttr.sequence.Value);
-                Assert.Equal(0, responseAttr.value);
                 Assert.NotEqual<uint>(0, responseAttr.creatorId);
                 Assert.NotEqual<uint>(0, responseAttr.editorId);
                 Assert.NotEqual<uint>(0, responseAttr.attributeId);
@@ -829,13 +830,11 @@ namespace SQE.ApiTest
 
                 // Update sequence and value of the new attribute
                 const byte seq = 1;
-                const float val = (float)1.2;
                 var updateSignInterpretationAddAttribute = new InterpretationAttributeCreateDTO
                 {
                     attributeId = 8,
                     attributeValueId = attributeValueId,
                     sequence = seq,
-                    value = val
                 };
                 var updRequest1 =
                     new Put.V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId(
@@ -865,7 +864,6 @@ namespace SQE.ApiTest
                 var upd1SignInterpretationAttribute = updData.attributes
                     .First(x => x.attributeValueId == attributeValueId);
                 Assert.Equal(seq, upd1SignInterpretationAttribute.sequence);
-                Assert.Equal(val, upd1SignInterpretationAttribute.value);
                 Assert.Null(upd1SignInterpretationAttribute.commentary);
 
                 // Update sequence and value of the new attribute
@@ -875,7 +873,6 @@ namespace SQE.ApiTest
                     attributeId = 8,
                     attributeValueId = attributeValueId,
                     sequence = seq,
-                    value = val,
                     commentary = commentary
                 };
                 var updRequest2 =
@@ -907,7 +904,6 @@ namespace SQE.ApiTest
                 var upd2SignInterpretationAttribute = updData.attributes
                     .First(x => x.attributeValueId == attributeValueId);
                 Assert.Equal(seq, upd2SignInterpretationAttribute.sequence);
-                Assert.Equal(val, upd2SignInterpretationAttribute.value);
                 Assert.NotNull(upd2SignInterpretationAttribute.commentary);
                 Assert.Equal(commentary, upd2SignInterpretationAttribute.commentary.commentary);
             }

--- a/sqe-api-test/TextTests.cs
+++ b/sqe-api-test/TextTests.cs
@@ -161,6 +161,7 @@ namespace SQE.ApiTest
                 msg.signs.First().signInterpretations.First().attributes.First().interpretationAttributeId
             );
             Assert.NotNull(msg.signs.First().signInterpretations.First().attributes.First().attributeValueString);
+            Assert.NotNull(msg.signs.First().signInterpretations.First().attributes.First().attributeString);
 
             var editorIds = new List<uint> { msg.editorId };
             foreach (var sign in msg.signs)
@@ -226,6 +227,14 @@ namespace SQE.ApiTest
                     .signInterpretations.First()
                     .attributes.First()
                     .attributeValueString
+            );
+            Assert.NotNull(
+                msg.textFragments.First()
+                    .lines.First()
+                    .signs.First()
+                    .signInterpretations.First()
+                    .attributes.First()
+                    .attributeString
             );
 
             var editorIds = new List<uint> { msg.editorId };

--- a/sqe-database-access/AttributeRepository.cs
+++ b/sqe-database-access/AttributeRepository.cs
@@ -17,9 +17,24 @@ namespace SQE.DatabaseAccess
 
         Task<IEnumerable<SignInterpretationAttributeEntry>> GetEditionAttributeAsync(UserInfo editionUser,
             uint attributeId);
-        Task<uint> CreateEditionAttribute(UserInfo editionUser, string attributeName, string attributeDescription, IEnumerable<SignInterpretationAttributeValueInput> attributeValues);
-        Task<uint> UpdateEditionAttribute(UserInfo editionUser, uint attributeId, string attributeName,
+        Task<uint> CreateEditionAttribute(
+            UserInfo editionUser,
+            string attributeName,
             string attributeDescription,
+            bool editable,
+            bool removable,
+            bool repeatable,
+            bool batchEditable,
+            IEnumerable<SignInterpretationAttributeValueInput> attributeValues);
+        Task<uint> UpdateEditionAttribute(
+            UserInfo editionUser,
+            uint attributeId,
+            string attributeName,
+            string attributeDescription,
+            bool editable,
+            bool removable,
+            bool repeatable,
+            bool batchEditable,
             IEnumerable<SignInterpretationAttributeValueInput> createAttributeValues,
             IEnumerable<SignInterpretationAttributeValue> updateAttributeValues,
             IEnumerable<uint> deleteAttributeValues);
@@ -45,7 +60,7 @@ namespace SQE.DatabaseAccess
             uint signInterpretationId);
 
         Task UpdateAttributeForSignInterpretationAsync(UserInfo editionUser,
-            uint signInterpretationId, uint attributeValueId, byte? sequence, float? numericValue);
+            uint signInterpretationId, uint attributeValueId, byte? sequence);
 
         Task<SignInterpretationAttributeData> GetSignInterpretationAttributeByIdAsync(UserInfo editionUser,
             uint signInterpretationAttributeId);
@@ -124,7 +139,7 @@ namespace SQE.DatabaseAccess
         /// <param name="attributeValues">A list of 0 or more possible values for the attribute</param>
         /// <returns>The unique id of the newly created attribute</returns>
         public async Task<uint> CreateEditionAttribute(UserInfo editionUser, string attributeName,
-            string attributeDescription, IEnumerable<SignInterpretationAttributeValueInput> attributeValues)
+            string attributeDescription, bool editable, bool removable, bool repeatable, bool batchEditable, IEnumerable<SignInterpretationAttributeValueInput> attributeValues)
         {
             using (var transactionScope = new TransactionScope())
             {
@@ -136,7 +151,14 @@ namespace SQE.DatabaseAccess
                     throw new StandardExceptions.ConflictingDataException("attribute");
 
                 // Write the new attribute
-                var newAttributeId = await _createOrUpdateEditionAttribute(editionUser, attributeName, attributeDescription);
+                var newAttributeId = await _createOrUpdateEditionAttribute(
+                    editionUser,
+                    attributeName,
+                    attributeDescription,
+                    editable,
+                    removable,
+                    repeatable,
+                    batchEditable);
 
                 // Write the new attribute values
                 await Task.WhenAll(attributeValues.Select(x =>
@@ -164,8 +186,15 @@ namespace SQE.DatabaseAccess
         /// <param name="updateAttributeValues">A list of attribute values to be updated</param>
         /// <param name="deleteAttributeValues">A list of attribute value ids to be deleted</param>
         /// <returns></returns>
-        public async Task<uint> UpdateEditionAttribute(UserInfo editionUser, uint attributeId, string attributeName,
+        public async Task<uint> UpdateEditionAttribute(
+            UserInfo editionUser,
+            uint attributeId,
+            string attributeName,
             string attributeDescription,
+            bool editable,
+            bool removable,
+            bool repeatable,
+            bool batchEditable,
             IEnumerable<SignInterpretationAttributeValueInput> createAttributeValues,
             IEnumerable<SignInterpretationAttributeValue> updateAttributeValues,
             IEnumerable<uint> deleteAttributeValues)
@@ -191,7 +220,15 @@ namespace SQE.DatabaseAccess
                 // Write the attribute update if we have a new name or description
                 var updatedAttributeID = string.IsNullOrEmpty(attributeName) && string.IsNullOrEmpty(attributeDescription) ?
                     attributeId
-                    : await _createOrUpdateEditionAttribute(editionUser, attributeName, attributeDescription, attributeId);
+                    : await _createOrUpdateEditionAttribute(
+                        editionUser,
+                        attributeName,
+                        attributeDescription,
+                        editable,
+                        removable,
+                        repeatable,
+                        batchEditable,
+                        attributeId);
 
                 // Merge the existing attribute values with the newly requested ones if a new attribute was created
                 if (updatedAttributeID != attributeId)
@@ -290,11 +327,15 @@ namespace SQE.DatabaseAccess
         // }
 
         private async Task<uint> _createOrUpdateEditionAttribute(UserInfo editionUser, string attributeName,
-            string attributeDescription, uint? attributeId = null)
+            string attributeDescription, bool editable, bool removable, bool repeatable, bool batchEditable, uint? attributeId = null)
         {
             var createParams = new DynamicParameters();
             createParams.Add("@name", attributeName);
             createParams.Add("@description", attributeDescription);
+            createParams.Add("@editable", editable);
+            createParams.Add("@removable", removable);
+            createParams.Add("@repeatable", repeatable);
+            createParams.Add("@batch_editable", batchEditable);
             var mutateRequest = new MutationRequest(
                 attributeId.HasValue ? MutateType.Update : MutateType.Create,
                 createParams,
@@ -602,9 +643,9 @@ namespace SQE.DatabaseAccess
         /// <param name="attributeValueId">Id of attribute value to update</param>
         /// <returns>List of ids of delete attributes</returns>
         public async Task UpdateAttributeForSignInterpretationAsync(UserInfo editionUser,
-            uint signInterpretationId, uint attributeValueId, byte? sequence, float? numericValue)
+            uint signInterpretationId, uint attributeValueId, byte? sequence)
         {
-            if (!sequence.HasValue && !numericValue.HasValue)
+            if (!sequence.HasValue)
                 return;
 
             var searchData = new SignInterpretationAttributeDataSearchData
@@ -619,11 +660,6 @@ namespace SQE.DatabaseAccess
 
             var attributeData =
                 await GetSignInterpretationAttributeByIdAsync(editionUser, signInterpretationAttributeId);
-
-            if (attributeData.NumericValue == numericValue && attributeData.Sequence == sequence)
-                return;
-
-            attributeData.NumericValue ??= numericValue;
             attributeData.Sequence ??= sequence;
 
             await UpdateSignInterpretationAttributesAsync(editionUser, signInterpretationId, new List<SignInterpretationAttributeData>() { attributeData });
@@ -681,7 +717,6 @@ namespace SQE.DatabaseAccess
                 signInterpretationAttributeParameters.Add("@sign_interpretation_id", signInterpretationId);
                 signInterpretationAttributeParameters.Add("@attribute_value_id", attribute.AttributeValueId);
                 signInterpretationAttributeParameters.Add("@sequence", attribute.Sequence);
-                signInterpretationAttributeParameters.Add("@numeric_value", attribute.NumericValue);
                 var signInterpretationAttributeRequest = new MutationRequest(
                     action,
                     signInterpretationAttributeParameters,

--- a/sqe-database-access/Helpers/SignInterpretationAttributeFactory.cs
+++ b/sqe-database-access/Helpers/SignInterpretationAttributeFactory.cs
@@ -71,8 +71,7 @@ namespace SQE.DatabaseAccess.Helpers
         {
             return new SignInterpretationAttributeData
             {
-                AttributeValueId = attributeValueId,
-                NumericValue = value
+                AttributeValueId = attributeValueId
             };
         }
     }

--- a/sqe-database-access/Models/SignInterpretationAttributeDataModels.cs
+++ b/sqe-database-access/Models/SignInterpretationAttributeDataModels.cs
@@ -35,6 +35,7 @@ namespace SQE.DatabaseAccess.Models
         public uint? SignInterpretationId { get; set; }
         public byte? Sequence { get; set; }
         public uint? AttributeId { get; set; }
+        public string AttributeString { get; set; }
         public uint? AttributeValueId { get; set; }
         public string AttributeValueString { get; set; }
         public uint? SignInterpretationAttributeCreatorId { get; set; }
@@ -73,5 +74,6 @@ namespace SQE.DatabaseAccess.Models
         public uint attributeId { get; set; }
         public uint attributeValueId { get; set; }
         public string attributeString { get; set; }
+        public string attributeValueString { get; set; }
     }
 }

--- a/sqe-database-access/Models/SignInterpretationAttributeDataModels.cs
+++ b/sqe-database-access/Models/SignInterpretationAttributeDataModels.cs
@@ -23,6 +23,10 @@ namespace SQE.DatabaseAccess.Models
         public uint AttributeEditor { get; set; }
         public uint AttributeValueCreator { get; set; }
         public uint AttributeValueEditor { get; set; }
+        public bool Editable { get; set; }
+        public bool Removable { get; set; }
+        public bool Repeatable { get; set; }
+        public bool BatchEditable { get; set; }
     }
 
     public class SignInterpretationAttributeData
@@ -35,13 +39,14 @@ namespace SQE.DatabaseAccess.Models
         public string AttributeValueString { get; set; }
         public uint? SignInterpretationAttributeCreatorId { get; set; }
         public uint? SignInterpretationAttributeEditorId { get; set; }
-        public float? NumericValue { get; set; }
+        public bool Editable { get; set; }
+        public bool Removable { get; set; }
+        public bool Repeatable { get; set; }
+        public bool BatchEditable { get; set; }
     }
 
     public class SignInterpretationAttributeDataSearchData : SignInterpretationAttributeData, ISearchData
     {
-        public float? NumericValueMoreThan { get; set; }
-        public float? NumericValueLessThan { get; set; }
 
         public string getSearchParameterString()
         {
@@ -53,9 +58,6 @@ namespace SQE.DatabaseAccess.Models
             if (AttributeValueId != null) searchParameters.Add($"attribute_value_id = {AttributeValueId}");
             if (SignInterpretationAttributeEditorId != null)
                 searchParameters.Add($"edition_editor_id = {SignInterpretationAttributeEditorId}");
-            if (NumericValue != null) searchParameters.Add($"numeric_value = {NumericValue}");
-            if (NumericValueMoreThan != null) searchParameters.Add($"numeric_value > {NumericValueMoreThan}");
-            if (NumericValueLessThan != null) searchParameters.Add($"numeric_value < {NumericValueLessThan}");
 
             return string.Join(" AND ", searchParameters);
         }

--- a/sqe-database-access/Queries/InterpretationAttributeQueries.cs
+++ b/sqe-database-access/Queries/InterpretationAttributeQueries.cs
@@ -10,6 +10,7 @@ namespace SQE.DatabaseAccess.Queries
 				       sequence as Sequence,
 				       sign_interpretation_attribute.creator_id AS SignInterpretationAttributeCreatorId,
 				       sign_interpretation_attribute_owner.edition_editor_id AS SignInterpretationAttributeEditorId,
+				       attribute.name as AttributeString,
 				       string_value as AttributeValueString,
 				       attribute.editable as Editable,
 				       attribute.removable as Removable,

--- a/sqe-database-access/Queries/InterpretationAttributeQueries.cs
+++ b/sqe-database-access/Queries/InterpretationAttributeQueries.cs
@@ -11,12 +11,18 @@ namespace SQE.DatabaseAccess.Queries
 				       sign_interpretation_attribute.creator_id AS SignInterpretationAttributeCreatorId,
 				       sign_interpretation_attribute_owner.edition_editor_id AS SignInterpretationAttributeEditorId,
 				       string_value as AttributeValueString,
-				       numeric_value as NumericValue
+				       attribute.editable as Editable,
+				       attribute.removable as Removable,
+				       attribute.repeatable as Repeatable,
+				       attribute.batch_editable as BatchEditable
 				FROM sign_interpretation_attribute
 				JOIN sign_interpretation_attribute_owner USING (sign_interpretation_attribute_id)
 				JOIN attribute_value USING (attribute_value_id)
+				JOIN attribute USING(attribute_id)
+				JOIN attribute_owner ON attribute_owner.attribute_id = attribute.attribute_id
+					AND attribute_owner.edition_id = sign_interpretation_attribute_owner.edition_id
 				WHERE @WhereData
-					AND edition_id=@EditionId
+					AND sign_interpretation_attribute_owner.edition_id=@EditionId
 				";
     }
 
@@ -44,7 +50,11 @@ SELECT attribute.attribute_id AS AttributeId,
        attribute_value.description AS AttributeStringValueDescription,
        attribute_value.creator_id AS AttributeValueCreator,
        attribute_value_owner.edition_editor_id AS AttributeValueEditor,
-       attr_css.css AS Css
+       attr_css.css AS Css,
+       attribute.editable as Editable,
+       attribute.removable as Removable,
+       attribute.repeatable as Repeatable,
+       attribute.batch_editable as BatchEditable
 FROM attribute 
 JOIN attribute_owner USING(attribute_id)
 JOIN attribute_value USING(attribute_id)

--- a/sqe-database-access/Queries/TextQueries.cs
+++ b/sqe-database-access/Queries/TextQueries.cs
@@ -363,8 +363,9 @@ WHERE text_fragment_data.text_fragment_id = @TextFragmentId
     {
         public const string GetQuery = @"
 SELECT DISTINCT attribute_value.attribute_value_id AS attributeValueId, 
-                attribute_value.string_value AS attributeString,
-                attribute_value.attribute_id AS attributeId
+                attribute_value.string_value AS attributeValueString,
+                attribute_value.attribute_id AS attributeId,
+                attribute.name AS attributeString
 FROM attribute_value
 JOIN attribute_value_owner 
 	ON attribute_value_owner.attribute_value_id = attribute_value.attribute_value_id 

--- a/sqe-database-access/Queries/TextQueries.cs
+++ b/sqe-database-access/Queries/TextQueries.cs
@@ -76,7 +76,6 @@ SELECT 	manuscript_data.manuscript_id AS manuscriptId,
 		sign_interpretation_attribute.creator_id AS SignInterpretationAttributeCreatorId,
 		sign_interpretation_attribute.sequence AS Sequence,
 		sign_interpretation_attribute_owner.edition_editor_id AS SignInterpretationAttributeEditorId,
-		sign_interpretation_attribute.numeric_value AS NumericValue,
 
 		roi.sign_interpretation_roi_id AS SignInterpretationRoiId,
 		roi.sign_interpretation_id AS SignInterpretationId,

--- a/sqe-database-access/TextRepository.cs
+++ b/sqe-database-access/TextRepository.cs
@@ -1083,12 +1083,12 @@ namespace SQE.DatabaseAccess
                         if (lastSignInterpretation.Attributes.Count == 0 ||
                             lastSignInterpretation.Attributes.Last().AttributeValueId != charAttribute.AttributeValueId)
                         {
-                            (charAttribute.AttributeValueString, charAttribute.AttributeId) = attributeDict.TryGetValue(
+                            (charAttribute.AttributeValueString, charAttribute.AttributeId, charAttribute.AttributeString) = attributeDict.TryGetValue(
                                 charAttribute.AttributeValueId.GetValueOrDefault(),
                                 out var val
                             )
-                                ? (val.attributeString, val.attributeId)
-                                : (null, 0);
+                                ? (val.attributeValueString, val.attributeId, val.attributeString)
+                                : (null, 0, null);
                             lastSignInterpretation.Attributes.Add(charAttribute);
                         }
 

--- a/sqe-dto/Sign.cs
+++ b/sqe-dto/Sign.cs
@@ -61,6 +61,7 @@ namespace SQE.API.DTO
     public class InterpretationAttributeDTO : InterpretationAttributeBaseDTO
     {
         [Required] public uint interpretationAttributeId { get; set; }
+        [Required] public string attributeString { get; set; }
         [Required] public string attributeValueString { get; set; }
         [Required] public uint creatorId { get; set; }
         [Required] public uint editorId { get; set; }

--- a/sqe-dto/Sign.cs
+++ b/sqe-dto/Sign.cs
@@ -51,7 +51,6 @@ namespace SQE.API.DTO
         public byte? sequence { get; set; }
         [Required] public uint attributeId { get; set; }
         [Required] public uint attributeValueId { get; set; }
-        public float? value { get; set; }
     }
 
     public class InterpretationAttributeCreateDTO : InterpretationAttributeBaseDTO
@@ -99,6 +98,10 @@ namespace SQE.API.DTO
     public class AttributeBaseDTO
     {
         public string description { get; set; }
+        public bool editable { get; set; }
+        public bool removable { get; set; }
+        public bool repeatable { get; set; }
+        public bool batchEditable { get; set; }
     }
 
     public class CreateAttributeDTO : AttributeBaseDTO
@@ -112,6 +115,10 @@ namespace SQE.API.DTO
         [Required] public CreateAttributeValueDTO[] createValues { get; set; }
         [Required] public UpdateAttributeValueDTO[] updateValues { get; set; }
         [Required] public uint[] deleteValues { get; set; }
+        public bool editable { get; set; }
+        public bool removable { get; set; }
+        public bool repeatable { get; set; }
+        public bool batchEditable { get; set; }
     }
 
     public class AttributeDTO : AttributeBaseDTO

--- a/ts-dtos/sqe-dtos.ts
+++ b/ts-dtos/sqe-dtos.ts
@@ -154,7 +154,6 @@ export interface InterpretationAttributeBaseDTO {
     sequence?: number;
     attributeId: number;
     attributeValueId: number;
-    value?: number;
 }
 
 export interface InterpretationAttributeCreateDTO extends InterpretationAttributeBaseDTO {
@@ -194,6 +193,10 @@ export interface AttributeValueDTO extends UpdateAttributeValueDTO {
 
 export interface AttributeBaseDTO {
     description?: string;
+    editable: boolean;
+    removable: boolean;
+    repeatable: boolean;
+    batchEditable: boolean;
 }
 
 export interface CreateAttributeDTO extends AttributeBaseDTO {
@@ -205,6 +208,10 @@ export interface UpdateAttributeDTO {
     createValues: Array<CreateAttributeValueDTO>;
     updateValues: Array<UpdateAttributeValueDTO>;
     deleteValues: Array<number>;
+    editable: boolean;
+    removable: boolean;
+    repeatable: boolean;
+    batchEditable: boolean;
 }
 
 export interface AttributeDTO extends AttributeBaseDTO {

--- a/ts-dtos/sqe-dtos.ts
+++ b/ts-dtos/sqe-dtos.ts
@@ -162,6 +162,7 @@ export interface InterpretationAttributeCreateDTO extends InterpretationAttribut
 
 export interface InterpretationAttributeDTO extends InterpretationAttributeBaseDTO {
     interpretationAttributeId: number;
+    attributeString: string;
     attributeValueString: string;
     creatorId: number;
     editorId: number;


### PR DESCRIPTION
@zmbq, here is the PR as promised.  You now have a field `attributeString` in the InterpretationAttributeDTO which gives the string name of the attribute (you only got the attributeId before).  Per our discusssion last week, I have introduced into the attribute system the boolean fields: editable, removable, repeatable, and batchEditable. You will receive information about these when you query the attribute system for an edition, and you can set them when adding/updating an attribute in an edition.