### PR TITLE
User registration update

### DIFF
--- a/sqe-api-server/HttpControllers/EditionController.cs
+++ b/sqe-api-server/HttpControllers/EditionController.cs
@@ -162,6 +162,7 @@ namespace SQE.API.Server.HttpControllers
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <returns></returns>
         [HttpGet("v1/[controller]s/{editionId}/script-collection")]
+        [AllowAnonymous]
         public async Task<ActionResult<EditionScriptCollectionDTO>> GetEditionScriptCollection(
             [FromRoute] uint editionId)
         {
@@ -176,6 +177,7 @@ namespace SQE.API.Server.HttpControllers
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <returns></returns>
         [HttpGet("v1/[controller]s/{editionId}/script-lines")]
+        [AllowAnonymous]
         public async Task<ActionResult<EditionScriptLinesDTO>> GetEditionScriptLines(
             [FromRoute] uint editionId)
         {

--- a/sqe-api-server/RealtimeHubs/EditionHub.cs
+++ b/sqe-api-server/RealtimeHubs/EditionHub.cs
@@ -225,7 +225,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <returns></returns>
-        [Authorize]
+        [AllowAnonymous]
         public async Task<EditionScriptCollectionDTO> GetV1EditionsEditionIdScriptCollection(uint editionId)
 
         {
@@ -246,7 +246,7 @@ namespace SQE.API.Server.RealtimeHubs
         /// </summary>
         /// <param name="editionId">Unique Id of the desired edition</param>
         /// <returns></returns>
-        [Authorize]
+        [AllowAnonymous]
         public async Task<EditionScriptLinesDTO> GetV1EditionsEditionIdScriptLines(uint editionId)
 
         {

--- a/sqe-api-server/appsettings.Development.json
+++ b/sqe-api-server/appsettings.Development.json
@@ -32,10 +32,10 @@
 
 	"ConnectionStrings": {
 		"MysqlHost": "127.0.0.1",
-		"MysqlPort": "3306",
+		"MysqlPort": "3307",
 		"MysqlDatabase": "SQE",
-		"MysqlUsername": "SQE",
-		"MysqlPassword": "saAsC4y92",
+		"MysqlUsername": "root",
+		"MysqlPassword": "none",
 		"MailerEmailAddress": "",
 		"MailerEmailUsername": "",
 		"MailerEmailPassword": "",

--- a/sqe-api-server/appsettings.Development.json
+++ b/sqe-api-server/appsettings.Development.json
@@ -32,10 +32,10 @@
 
 	"ConnectionStrings": {
 		"MysqlHost": "127.0.0.1",
-		"MysqlPort": "3307",
+		"MysqlPort": "3306",
 		"MysqlDatabase": "SQE",
-		"MysqlUsername": "root",
-		"MysqlPassword": "none",
+		"MysqlUsername": "SQE",
+		"MysqlPassword": "saAsC4y92",
 		"MailerEmailAddress": "",
 		"MailerEmailUsername": "",
 		"MailerEmailPassword": "",

--- a/sqe-api-test/ArtefactGroupTests.cs
+++ b/sqe-api-test/ArtefactGroupTests.cs
@@ -260,6 +260,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "ArtefactGroup")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanCreateAndDeleteArtefactGroups(bool realtime)
@@ -307,6 +308,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "ArtefactGroup")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CannotPerformBadUpdateToArtefactGroup(bool realtime)
@@ -384,6 +386,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "ArtefactGroup")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CannotReuseArtefactsInArtefactGroup(bool realtime)
@@ -458,6 +461,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "ArtefactGroup")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanUpdateArtefactGroups(bool realtime)

--- a/sqe-api-test/ArtefactTests.cs
+++ b/sqe-api-test/ArtefactTests.cs
@@ -70,6 +70,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanAccessArtefacts()
         {
             // Act
@@ -89,6 +90,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanBatchUnplaceArtefacts()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -212,6 +214,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanCreateArtefacts()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -313,6 +316,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanDeleteArtefacts()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -350,6 +354,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanGetSuggestedTextFragmentForArtefact()
         {
             // Arrange
@@ -378,6 +383,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CannotCreateArtefactsOnUnownedEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -428,6 +434,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CannotCreateMalformedArtefact()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -701,6 +708,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CannotDeleteUnownedArtefacts()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -728,6 +736,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CannotUpdateUnownedArtefacts()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -761,6 +770,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanUpdateArtefacts()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -920,6 +930,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task RejectsUpdateToImproperArtefactShape()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -951,6 +962,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Artefact")]
         public async Task CanGetEditionArtefactRois()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))

--- a/sqe-api-test/CatalogueTests.cs
+++ b/sqe-api-test/CatalogueTests.cs
@@ -11,6 +11,7 @@ namespace SQE.ApiTest
     public partial class WebControllerTest
     {
         [Fact]
+        [Trait("Category", "Catalogue")]
         public async Task CanGetImagedObjectsForTextFragments()
         {
             var requestObj = new Get.V1_Catalogue_TextFragments_TextFragmentId_ImagedObjects(9977);
@@ -24,6 +25,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Catalogue")]
         public async Task CanGetTextFragmentsForImagedObjects()
         {
             var requestObj = new Get.V1_Catalogue_ImagedObjects_ImagedObjectId_TextFragments("IAA-1094-1");
@@ -36,6 +38,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Catalogue")]
         public async Task CanGetImagedObjectsAndTextFragmentsOfEdition()
         {
             // Act
@@ -43,6 +46,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Catalogue")]
         public async Task CanGetImagedObjectsAndTextFragmentsOfManuscript()
         {
             // Act
@@ -50,6 +54,7 @@ namespace SQE.ApiTest
         }
 
         [Theory]
+        [Trait("Category", "Catalogue")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanCreateNewImagedObjectTextFragmentMatch(bool realtime)

--- a/sqe-api-test/DbConnectionBaseTest.cs
+++ b/sqe-api-test/DbConnectionBaseTest.cs
@@ -91,6 +91,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Database Retries")]
         public void RetryPoliciesShouldNotRepeat()
         {
             // Arrange
@@ -110,6 +111,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Database Retries")]
         public async Task RetryPoliciesShouldRepeat()
         {
             // Arrange
@@ -187,6 +189,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Database Retries")]
         public async Task ShortCircuitShouldEngage()
         {
             // Arrange
@@ -269,6 +272,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Database Retries")]
         public void ShortCircuitShouldNotEngage()
         {
             // Arrange

--- a/sqe-api-test/EditionTests.cs
+++ b/sqe-api-test/EditionTests.cs
@@ -116,6 +116,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanAdminShareEdition()
         {
             // Arrange
@@ -188,6 +189,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanChangeEditionSharePermissions()
         {
             // Arrange
@@ -306,6 +308,7 @@ namespace SQE.ApiTest
         // TODO: write the rest of the tests.
         // TODO: finish updating tests to use new request objects.
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task CanDeleteEditionAsAdmin()
         {
             // Arrange
@@ -344,6 +347,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task CanDuplicateCopiedEdition()
         {
             // ARRANGE
@@ -358,6 +362,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanLockableShareEdition()
         {
             // Arrange
@@ -398,6 +403,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanNotAdminWithoutReadShareEdition()
         {
             // Arrange
@@ -476,6 +482,7 @@ namespace SQE.ApiTest
 
         // TODO: finish updating test to use new request objects.
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task CanNotDeleteEditionWhenAnonymous()
         {
             // Arrange
@@ -507,6 +514,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanNotWriteWithoutReadShareEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -579,6 +587,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanProperlyDeleteSharedEdition()
         {
             // Arrange
@@ -706,6 +715,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanViewOutstandingShareInvitations()
         {
             // Arrange
@@ -765,6 +775,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanViewOutstandingShareRequests()
         {
             // Arrange
@@ -826,6 +837,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Edition Sharing")]
         public async Task CanWriteShareEdition()
         {
             // Arrange
@@ -918,6 +930,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task CreateEdition()
         {
             // ARRANGE (with name)
@@ -976,6 +989,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task GetAllEditionsUnauthenticated()
         {
             // ARRANGE
@@ -998,6 +1012,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task GetOneEditionUnauthenticated()
         {
             // ARRANGE
@@ -1024,6 +1039,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task GetPrivateEditions()
         {
             // ARRANGE
@@ -1077,6 +1093,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task RefuseUnauthenticatedEditionWrite()
         {
             // ARRANGE
@@ -1112,6 +1129,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Edition")]
         public async Task UpdateEdition()
         {
             // ARRANGE
@@ -1167,6 +1185,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Edition Script")]
         public async Task CanGetEditionScriptChart()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -1207,6 +1226,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Edition Script")]
         public async Task CanGetEditionLineScriptChart()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))

--- a/sqe-api-test/Helpers/UserHelpers.cs
+++ b/sqe-api-test/Helpers/UserHelpers.cs
@@ -110,11 +110,13 @@ namespace SQE.ApiTest.Helpers
         private static async Task CleanupUserAccountAsync(UserDTO user, DatabaseQuery db)
         {
             const string deleteNewUserSql = "DELETE FROM user WHERE email = @Email";
+            const string deleteUserRoleSQL = "DELETE FROM users_system_roles WHERE user_id = @UserID";
             const string deleteEmailTokenSql = "DELETE FROM user_email_token WHERE user_id = @UserId";
             var deleteEmailTokenParams = new DynamicParameters();
             deleteEmailTokenParams.Add("@UserId", user.userId);
             deleteEmailTokenParams.Add("@Email", user.email);
             await db.RunExecuteAsync(deleteEmailTokenSql, deleteEmailTokenParams);
+            await db.RunExecuteAsync(deleteUserRoleSQL, deleteEmailTokenParams);
             await db.RunExecuteAsync(deleteNewUserSql, deleteEmailTokenParams);
         }
 

--- a/sqe-api-test/ImagedObjectTests.cs
+++ b/sqe-api-test/ImagedObjectTests.cs
@@ -40,6 +40,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Imaged Object")]
         public async Task CanDecodeImagedObjectIdWithUrlEncodedValue()
         {
             // Note: the dotnet HTTP Request system automatically escapes the URL's we submit,
@@ -61,6 +62,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Imaged Object")]
         public async Task CanGetImagedObjectInstitutions()
         {
             // Act
@@ -77,6 +79,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "Imaged Object")]
         [InlineData(true, false)]
         [InlineData(true, true)]
         [InlineData(false, false)]
@@ -120,6 +123,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "Imaged Object")]
         [InlineData(true, false)]
         [InlineData(true, true)]
         [InlineData(false, false)]
@@ -170,12 +174,14 @@ namespace SQE.ApiTest
 
 
         [Fact]
+        [Trait("Category", "Imaged Object")]
         public async Task CanGetInstitutionalImages()
         {
             await ImagedObjectHelpers.GetInstitutionImagedObjects("IAA", _client, StartConnectionAsync);
         }
 
         [Fact]
+        [Trait("Category", "Imaged Object")]
         public async Task CanGetSpecifiedImagedObject()
         {
             // Arrange
@@ -191,6 +197,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Imaged Object")]
         public async Task CanGetImagedObjectTextFragment()
         {
             // Note that "IAA-1039-1" had text fragment matches at the time this test was written.

--- a/sqe-api-test/RoiTests.cs
+++ b/sqe-api-test/RoiTests.cs
@@ -16,6 +16,7 @@ namespace SQE.ApiTest
     public partial class WebControllerTest
     {
         [Fact]
+        [Trait("Category", "Roi")]
         public async Task CanCreateEditionRoi()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -26,6 +27,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Roi")]
         public async Task CanBatchCreateEditionRoi()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -36,6 +38,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Roi")]
         public async Task CanGetEditionRoi()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -54,6 +57,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Roi")]
         public async Task CanDeleteEditionRoi()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -93,12 +97,14 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Roi")]
         public async Task CanUpdateEditionRoi()
         {
             await UpdateEditionRoi(false);
         }
 
         [Fact]
+        [Trait("Category", "Roi")]
         public async Task CanBatchUpdateEditionRoi()
         {
             await UpdateEditionRoi(true);
@@ -171,6 +177,7 @@ namespace SQE.ApiTest
         }
 
         [Theory]
+        [Trait("Category", "Roi")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanBatchEditRois(bool realtime)

--- a/sqe-api-test/SignInterpretationTests.cs
+++ b/sqe-api-test/SignInterpretationTests.cs
@@ -48,6 +48,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanAddAttributeToEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -111,6 +112,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanCreateNewAttributeForSignInterpretation()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -161,6 +163,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanCreateAndDeleteSignInterpretation()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -300,6 +303,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanLinkSignInterpretations()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -353,6 +357,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanUnlinkSignInterpretations()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -405,6 +410,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanCreateSignInterpretationCommentary()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -482,6 +488,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanDeleteAttributeFromEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -524,6 +531,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanDeleteAttributeFromSignInterpretation()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -607,6 +615,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanGetAllEditionSignInterpretationAttributes()
         {
             // Arrange
@@ -636,6 +645,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanGetAttributesOfSpecificSignInterpretation()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -668,6 +678,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanUpdateAttributeInEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -789,6 +800,7 @@ namespace SQE.ApiTest
         // }
 
         [Fact]
+        [Trait("Category", "Sign Interpretation")]
         public async Task CanUpdateAttributeOfSignInterpretation()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))

--- a/sqe-api-test/TextTests.cs
+++ b/sqe-api-test/TextTests.cs
@@ -265,6 +265,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanAddTextFragmentAfter()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -322,6 +323,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanAddTextFragmentBefore()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -381,6 +383,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanAddTextFragmentBeforeAndAfter()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -430,6 +433,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanAddTextFragmentToEnd()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -464,6 +468,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanGetAnonymousEditionTextFragment()
         {
             // Arrange
@@ -487,6 +492,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanGetAnonymousArtefactsOfTextFragment()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -510,6 +516,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanGetAnonymousEditionTextFragmentData()
         {
             // Arrange
@@ -528,6 +535,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanGetAnonymousEditionTextLine()
         {
             // Arrange
@@ -547,6 +555,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanGetAnonymousEditionTextLineData()
         {
             // Arrange
@@ -570,6 +579,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanMoveTextFragmentAfter()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -616,6 +626,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanMoveTextFragmentBefore()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -660,6 +671,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanMoveTextFragmentBeforeAndAfter()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -705,6 +717,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CanMoveTextFragmentBetweenNonsequentialTextFragments()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -744,6 +757,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotAddTextFragmentAfterTextFragmentNotInEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -778,6 +792,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotAddTextFragmentBeforeTextFragmentNotInEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -813,6 +828,7 @@ namespace SQE.ApiTest
 
         // It is probably best from the perspective of the API consumer that this test should pass.
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotAddTextFragmentBetweenNonSequentialTextFragments()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -849,6 +865,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotAddTextFragmentWithBlankName()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -883,6 +900,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotAddTextFragmentWithNullName()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -917,6 +935,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotAddTextFragmentWithoutPermission()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -939,6 +958,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotMoveTextFragmentAfterTextFragmentNotInEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))
@@ -978,6 +998,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Text")]
         public async Task CannotMoveTextFragmentBeforeTextFragmentNotInEdition()
         {
             using (var editionCreator = new EditionHelpers.EditionCreator(_client, StartConnectionAsync))

--- a/sqe-api-test/UserTests.cs
+++ b/sqe-api-test/UserTests.cs
@@ -25,6 +25,7 @@ namespace SQE.ApiTest
 
 
         [Fact]
+        [Trait("Category", "Authentication")]
         public async Task RejectUnauthenticatedGetRequest()
         {
             // Act
@@ -36,6 +37,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Authentication")]
         public async Task RejectUnauthenticatedPostRequests()
         {
             // Act
@@ -47,6 +49,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Authentication")]
         public async Task RejectUnauthenticatedPutRequests()
         {
             // Act
@@ -226,11 +229,13 @@ namespace SQE.ApiTest
         private async Task CleanupUserAccountAsync(UserDTO user)
         {
             const string deleteNewUserSQL = "DELETE FROM user WHERE email = @Email";
+            const string deleteUserRoleSQL = "DELETE FROM users_system_roles WHERE user_id = @UserID";
             const string deleteEmailTokenSQL = "DELETE FROM user_email_token WHERE user_id = @UserId";
             var deleteEmailTokenParams = new DynamicParameters();
             deleteEmailTokenParams.Add("@UserId", user.userId);
             deleteEmailTokenParams.Add("@Email", user.email);
             await _db.RunExecuteAsync(deleteEmailTokenSQL, deleteEmailTokenParams);
+            await _db.RunExecuteAsync(deleteUserRoleSQL, deleteEmailTokenParams);
             await _db.RunExecuteAsync(deleteNewUserSQL, deleteEmailTokenParams);
         }
 
@@ -239,6 +244,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task AccountDetailsUpdateFailsWithWrongPassword()
         {
             var user = new NewUserRequestDTO(
@@ -281,6 +287,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task AccountPasswordUpdateFailsWithWrongEnteredPassword()
         {
             var user = new NewUserRequestDTO(
@@ -322,6 +329,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task CanRegisterUserAccount()
         {
             // ARRANGE
@@ -373,6 +381,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task CanResendAccountActivation()
         {
             // ARRANGE
@@ -419,6 +428,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task CanUpdateDetailsBeforeActivation()
         {
             UserDTO updatedUser = null;
@@ -464,6 +474,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "User Account")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ChangeActivatedAccountPassword(bool realtime)
@@ -521,6 +532,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "User Account")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ChangeActivatedAccountUserDetails(bool realtime)
@@ -588,6 +600,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "User Account")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ChangeActivatedAccountUserDetailsWithoutEmail(bool realtime)
@@ -651,6 +664,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "User Account")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ChangeUnactivatedAccountEmail(bool realtime)
@@ -704,6 +718,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task DontAllowDuplicateAccounts()
         {
             // Arrange
@@ -723,6 +738,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Authentication")]
         public async Task DontAllowUnauthenticatedUsersToHaveJwt()
         {
             // Arrange
@@ -750,6 +766,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Fact]
+        [Trait("Category", "Authentication")]
         public async Task NonexistentAccountsShouldNotLogin()
         {
             // Arrange
@@ -770,6 +787,7 @@ namespace SQE.ApiTest
         /// </summary>
         /// <returns></returns>
         [Theory]
+        [Trait("Category", "User Account")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResetActivatedAccountPassword(bool realtime)
@@ -836,6 +854,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "User Account")]
         public async Task CanGetUserDetails()
         {
             // Arrange

--- a/sqe-api-test/UtilTests.cs
+++ b/sqe-api-test/UtilTests.cs
@@ -16,6 +16,7 @@ namespace SQE.ApiTest
         // The tests here are geared towards checking the API endpoints
 
         [Fact]
+        [Trait("Category", "Utilities")]
         public async Task CanRecognizeValidWktPolygons()
         {
             var goodPolygon = new WktPolygonDTO
@@ -40,6 +41,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Utilities")]
         public async Task RepairsInvalidWktPolygons()
         {
             var badPolygon = new WktPolygonDTO

--- a/sqe-api-test/ValidationTests.cs
+++ b/sqe-api-test/ValidationTests.cs
@@ -36,6 +36,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void AutoFixesBadInnerOuterPolys()
         {
             const string inputPoly =
@@ -46,6 +47,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void DoesNotSimplifyMinuteFeatures()
         {
             var inputPoly = "POLYGON ((0 0,0.000000000001 5,0 10,10 10,9.99999999999 5,10 0,0 0))";
@@ -53,6 +55,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesAdjacentInnerRingsPolys()
         {
             const string inputPoly = "POLYGON((0 0,10 0,10 10,0 10,0 0),(1 1,1 8,3 8,3 1,1 1),(3 1,3 8,5 8,5 1,3 1))";
@@ -62,6 +65,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesDanglingEdgeErrorPoly()
         {
             const string inputPoly = "POLYGON((0 0, 10 0, 10 10, 15 5, 10 10, 0 10, 0 0))";
@@ -70,6 +74,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesInnerOuterEdgeErrorPoly()
         {
             const string inputPoly = "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),(5 2,5 7,10 7, 10 2, 5 2))";
@@ -79,6 +84,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesNestedInnerPolys()
         {
             const string inputPoly =
@@ -88,6 +94,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesOpenPoly()
         {
             const string inputPoly = "POLYGON((0 0, 10 0, 10 10, 0 10))";
@@ -96,6 +103,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesSelfIntersectingErrorPoly1()
         {
             var inputPoly =
@@ -106,6 +114,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesSelfIntersectingErrorPoly2()
         {
             var inputPoly = "POLYGON ((0 0, 15 20, 20 30, 25 45, 30 100, 45 40, 47 0, 50 1, 55 5, 50 10, 45 5, 0 0))";
@@ -115,6 +124,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesSelfIntersectingErrorPoly3()
         {
             var inputPoly =
@@ -125,6 +135,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesUnclosedPolys()
         {
             const string inputPoly = "POLYGON ((0 0, 0 200, 200 200, 200 0), (50 150, 150 150, 150 50, 50 50))";
@@ -134,6 +145,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesVeryComplexBadPolys()
         {
             var inputPoly =
@@ -144,6 +156,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void FixesWrongOrientationPolys()
         {
             const string inputPoly = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))";
@@ -152,6 +165,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void MergesVeryClosePolys()
         {
             const string inputPoly = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0),(11 11, 11 20, 20 20, 20 11, 11 11))";
@@ -161,6 +175,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void RemovesUnneededPoints()
         {
             var inputPoly = "POLYGON ((0 0,5 0,10 0,10 10,0 10,0 0))";
@@ -169,6 +184,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void RemovesUnneededPointsFromFixedPoly()
         {
             var inputPoly = "POLYGON ((0 0,5 0,10 0,0 10,5 10,10 10,0 0))";
@@ -178,6 +194,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void ValidDecimalAttributeForPrecisionAndScale()
         {
             var errorThrown = false;
@@ -214,6 +231,7 @@ namespace SQE.ApiTest
         }
 
         [Fact]
+        [Trait("Category", "Polygon Validation")]
         public void ValidDecimalAttributeRejectsInvalidDecimal()
         {
             // Set decimal precision to 4 places to the left of decimal point and 2 places to its right

--- a/sqe-database-access/CatalogueRepository.cs
+++ b/sqe-database-access/CatalogueRepository.cs
@@ -105,7 +105,7 @@ namespace SQE.DatabaseAccess
                         Comment = comment,
                         EditionId = editionId,
                         UserId = userId
-                    })).ToList();
+                    })).AsList();
                 var editionCatalogueId = existingEditionCats.Any()
                     ? existingEditionCats.First().IaaEditionCatalogId
                     : (uint?)null;

--- a/sqe-database-access/DbConnectionBase.cs
+++ b/sqe-database-access/DbConnectionBase.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using MySql.Data.MySqlClient;
 using Polly;
 using Serilog;
+using IsolationLevel = System.Data.IsolationLevel;
 
 namespace SQE.DatabaseAccess
 {
@@ -242,7 +243,7 @@ namespace SQE.DatabaseAccess
         }
 
         // Set the _connectionString for this class and the ConnectionString of the underlying MySqlConnection.
-        public sealed override string ConnectionString
+        public override string ConnectionString
         {
             get => _connectionString;
 
@@ -345,7 +346,7 @@ namespace SQE.DatabaseAccess
             set => _underlyingSqlCommand.CommandType = value;
         }
 
-        protected sealed override DbConnection DbConnection
+        protected override DbConnection DbConnection
         {
             get => _underlyingSqlCommand.Connection;
             set => _underlyingSqlCommand.Connection = (MySqlConnection)value; // Cast to a MySqlConnection for safety
@@ -353,7 +354,7 @@ namespace SQE.DatabaseAccess
 
         protected override DbParameterCollection DbParameterCollection => _underlyingSqlCommand.Parameters;
 
-        protected sealed override DbTransaction DbTransaction
+        protected override DbTransaction DbTransaction
         {
             get => _underlyingSqlCommand.Transaction;
             set => _underlyingSqlCommand.Transaction =

--- a/sqe-database-access/DbConnectionBase.cs
+++ b/sqe-database-access/DbConnectionBase.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Configuration;
 using MySql.Data.MySqlClient;
 using Polly;
 using Serilog;
-using IsolationLevel = System.Data.IsolationLevel;
 
 namespace SQE.DatabaseAccess
 {

--- a/sqe-database-access/Helpers/AsyncFlowTransactionScope.cs
+++ b/sqe-database-access/Helpers/AsyncFlowTransactionScope.cs
@@ -1,0 +1,12 @@
+using System.Transactions;
+
+namespace SQE.DatabaseAccess.Helpers
+{
+    public static class AsyncFlowTransaction
+    {
+        public static TransactionScope GetScope()
+        {
+            return new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        }
+    }
+}

--- a/sqe-database-access/Queries/UserQueries.cs
+++ b/sqe-database-access/Queries/UserQueries.cs
@@ -246,4 +246,15 @@ FROM edition_editor
 JOIN user USING(user_id)
 WHERE edition_editor.edition_id = @EditionId";
     }
+
+    internal static class SetUserSystemRole
+    {
+        public const string GetQuery = @"
+INSERT INTO users_system_roles (user_id, system_roles_id)
+SELECT user_id, system_roles_id
+FROM system_roles
+JOIN user_email_token ON user_email_token.token = @Token
+WHERE system_roles.role_title = @SystemRole
+ON DUPLICATE KEY UPDATE user_id = VALUES(user_id)";
+    }
 }

--- a/sqe-database-access/SignInterpretationRepository.cs
+++ b/sqe-database-access/SignInterpretationRepository.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using Dapper;
 using Microsoft.Extensions.Configuration;
+using SQE.DatabaseAccess.Helpers;
 using SQE.DatabaseAccess.Models;
 using SQE.DatabaseAccess.Queries;
 
@@ -34,7 +35,7 @@ namespace SQE.DatabaseAccess
         {
             // We use several existing quick functions to get the specifics of a sign interpretation,
             // so wrap it in a transaction to make sure the result is consistent.
-            using (var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            using (var transactionScope = AsyncFlowTransaction.GetScope())
             using (var conn = OpenConnection())
             {
                 var attributes =
@@ -44,6 +45,8 @@ namespace SQE.DatabaseAccess
                         signInterpretationId);
                 var roiIds =
                     await _roiRepository.GetSignInterpretationRoisIdsByInterpretationId(user, signInterpretationId);
+
+                // TODO: perhaps create method that does can get all the ROIs with one query
                 var rois = new SignInterpretationRoiData[roiIds.Count];
                 foreach (var (roiId, index) in roiIds.Select((x, idx) => (x, idx)))
                     rois[index] = await _roiRepository.GetSignInterpretationRoiByIdAsync(user, roiId);


### PR DESCRIPTION
This is the kind of PR I hope to be making in the future—it should be pretty small and manageable.

First, I have addressed most (but not quite all) of your helpful comments from the last PR.

Second, I realized that our user registration code did not yet incorporate a write to the user_system_roles table.  That is the main contribution of this PR, and now all registered users are immediately given the system role of REGISTERED_USER.  I have not added admin endpoints yet to enable the setting of other possibl roles for users.

Thirdly, I add a check and correction for a possible error that can come up in one of the GIS serializers, and wrote a note to submit a bug report to NetTopologySuite (basically transforming a valid polygon may possibly result in an invalid polygon).

Finally, I added category traits to the integration tests to make it a bit easier to navigate them.