### PR TITLE
Catalogue fixes

### DIFF
--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.21.1
+        image: qumranica/sqe-database:0.21.2
         container_name: SQE_Database
         environment:
             ## These must be updated when used in production

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.21.0
+        image: qumranica/sqe-database:0.21.1
         container_name: SQE_Database
         environment:
             ## These must be updated when used in production

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.21.0
+        image: qumranica/sqe-database:0.21.1
         container_name: SQE_Database
         # These environment variables match the default db connection settings for the project.
         environment:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.7'
 
 services:
     sqe-database:
-        image: qumranica/sqe-database:0.21.1
+        image: qumranica/sqe-database:0.21.2
         container_name: SQE_Database
         # These environment variables match the default db connection settings for the project.
         environment:

--- a/sqe-api-server/HttpControllers/UserController.cs
+++ b/sqe-api-server/HttpControllers/UserController.cs
@@ -150,7 +150,6 @@ namespace SQE.API.Server.HttpControllers
         /// <summary>
         /// Retrieve the information in the user's personal data store
         /// </summary>
-        /// <param name="data">A JSON object with the data to store for the user</param>
         /// <returns></returns>
         [HttpGet("v1/[controller]s/data-store")]
         public async Task<ActionResult<UserDataStoreDTO>> GetUserDataStore()

--- a/sqe-api-server/HttpControllers/UserController.cs
+++ b/sqe-api-server/HttpControllers/UserController.cs
@@ -146,5 +146,27 @@ namespace SQE.API.Server.HttpControllers
         {
             return await _userService.ResendActivationEmail(payload.email);
         }
+
+        /// <summary>
+        /// Retrieve the information in the user's personal data store
+        /// </summary>
+        /// <param name="data">A JSON object with the data to store for the user</param>
+        /// <returns></returns>
+        [HttpGet("v1/[controller]s/data-store")]
+        public async Task<ActionResult<UserDataStoreDTO>> GetUserDataStore()
+        {
+            return await _userService.GetUserDataStoreAsync(_userService.GetCurrentUserId());
+        }
+
+        /// <summary>
+        /// Update the information in the user's personal data store
+        /// </summary>
+        /// <param name="data">A JSON object with the data to store for the user</param>
+        /// <returns></returns>
+        [HttpPut("v1/[controller]s/data-store")]
+        public async Task<ActionResult> UpdateUserDataStore([FromBody] UserDataStoreDTO data)
+        {
+            return await _userService.SetUserDataStoreAsync(_userService.GetCurrentUserId(), data);
+        }
     }
 }

--- a/sqe-api-server/RealtimeHubs/UserHub.cs
+++ b/sqe-api-server/RealtimeHubs/UserHub.cs
@@ -225,5 +225,45 @@ namespace SQE.API.Server.RealtimeHubs
         }
 
 
+        /// <summary>
+        /// Retrieve the information in the user's personal data store
+        /// </summary>
+        /// <param name="data">A JSON object with the data to store for the user</param>
+        /// <returns></returns>
+        [Authorize]
+        public async Task<UserDataStoreDTO> GetV1UsersDataStore()
+
+        {
+            try
+            {
+                return await _userService.GetUserDataStoreAsync(_userService.GetCurrentUserId());
+            }
+            catch (ApiException err)
+            {
+                throw new HubException(JsonSerializer.Serialize(new HttpExceptionMiddleware.ApiExceptionError(nameof(err), err.Error, err is IExceptionWithData exceptionWithData ? exceptionWithData.CustomReturnedData : null)));
+            }
+        }
+
+
+        /// <summary>
+        /// Update the information in the user's personal data store
+        /// </summary>
+        /// <param name="data">A JSON object with the data to store for the user</param>
+        /// <returns></returns>
+        [Authorize]
+        public async Task PutV1UsersDataStore(UserDataStoreDTO data)
+
+        {
+            try
+            {
+                await _userService.SetUserDataStoreAsync(_userService.GetCurrentUserId(), data, clientId: Context.ConnectionId);
+            }
+            catch (ApiException err)
+            {
+                throw new HubException(JsonSerializer.Serialize(new HttpExceptionMiddleware.ApiExceptionError(nameof(err), err.Error, err is IExceptionWithData exceptionWithData ? exceptionWithData.CustomReturnedData : null)));
+            }
+        }
+
+
     }
 }

--- a/sqe-api-server/RealtimeHubs/UserHub.cs
+++ b/sqe-api-server/RealtimeHubs/UserHub.cs
@@ -228,7 +228,6 @@ namespace SQE.API.Server.RealtimeHubs
         /// <summary>
         /// Retrieve the information in the user's personal data store
         /// </summary>
-        /// <param name="data">A JSON object with the data to store for the user</param>
         /// <returns></returns>
         [Authorize]
         public async Task<UserDataStoreDTO> GetV1UsersDataStore()

--- a/sqe-api-server/Services/EditionService.cs
+++ b/sqe-api-server/Services/EditionService.cs
@@ -564,7 +564,10 @@ The Scripta Qumranica Electronica team</body></html>";
                 locked = model.Locked,
                 isPublic = model.IsPublic,
                 lastEdit = model.LastEdit,
-                copyright = model.Copyright,
+                copyright = model.Copyright ?? Licence.printLicence(
+                    model.CopyrightHolder,
+                    model.Collaborators,
+                    model.Editors),
                 shares = model.Editors.Select(x => new DetailedEditorRightsDTO
                 {
                     email = x.EditorEmail,

--- a/sqe-api-server/Services/UserService.cs
+++ b/sqe-api-server/Services/UserService.cs
@@ -420,7 +420,7 @@ The Scripta Qumranica Electronica team</body></html>";
         /// <summary>
         /// Retrieve the information from the user's data store
         /// </summary>
-        /// <param name="userID">Id of the user requesting the store</param>
+        /// <param name="userId">Id of the user requesting the store</param>
         /// <returns></returns>
         public async Task<UserDataStoreDTO> GetUserDataStoreAsync(uint? userId)
         {
@@ -437,6 +437,7 @@ The Scripta Qumranica Electronica team</body></html>";
         /// </summary>
         /// <param name="userId">Id of the user requesting an update to the store</param>
         /// <param name="data">The data in JSON format to be stored in the database</param>
+        /// <param name="clientId">Id of the calling signalr client</param>
         /// <returns></returns>
         public async Task<NoContentResult> SetUserDataStoreAsync(uint? userId, UserDataStoreDTO data, string clientId = null)
         {

--- a/sqe-api-server/Services/UserService.cs
+++ b/sqe-api-server/Services/UserService.cs
@@ -2,6 +2,7 @@ using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -56,6 +57,8 @@ namespace SQE.API.Server.Services
 
         Task<NoContentResult> RequestResetLostPasswordAsync(string email, string clientId = null);
         Task<NoContentResult> ResetLostPasswordAsync(string token, string password, string clientId = null);
+        Task<UserDataStoreDTO> GetUserDataStoreAsync(uint? userId);
+        Task<NoContentResult> SetUserDataStoreAsync(uint? userId, UserDataStoreDTO data, string clientId = null);
     }
 
     public class UserService : IUserService
@@ -411,6 +414,52 @@ The Scripta Qumranica Electronica team</body></html>";
                 emailBody.Replace("$User", name)
             );
 
+            return new NoContentResult();
+        }
+
+        /// <summary>
+        /// Retrieve the information from the user's data store
+        /// </summary>
+        /// <param name="userID">Id of the user requesting the store</param>
+        /// <returns></returns>
+        public async Task<UserDataStoreDTO> GetUserDataStoreAsync(uint? userId)
+        {
+            if (!userId.HasValue)
+                throw new StandardExceptions.NoAuthorizationException();
+            return new UserDataStoreDTO()
+            {
+                data = await _userRepository.GetUserDataStoreAsync(userId.Value)
+            };
+        }
+
+        /// <summary>
+        /// Set the information in the user's data store
+        /// </summary>
+        /// <param name="userId">Id of the user requesting an update to the store</param>
+        /// <param name="data">The data in JSON format to be stored in the database</param>
+        /// <returns></returns>
+        public async Task<NoContentResult> SetUserDataStoreAsync(uint? userId, UserDataStoreDTO data, string clientId = null)
+        {
+            if (!userId.HasValue)
+                throw new StandardExceptions.NoAuthorizationException();
+
+            // Make sure the string is not too long (we'll cap it at a million characters for now)
+            if (data.data.Length > 1000000)
+                throw new StandardExceptions.InputDataRuleViolationException(
+                    "data may not exceed 1,000,000 characters in the user personal data store");
+
+            // Make sure the string is valid JSON (we don't use a guard in the database)
+            try
+            {
+                var _ = JsonSerializer.Deserialize<object>(data.data);
+            }
+            catch (JsonException ex)
+            {
+                throw new StandardExceptions.InputDataRuleViolationException(
+                    $"data must be a valid JSON entity ({ex})");
+            }
+
+            await _userRepository.SetUserDataStoreAsync(userId.Value, data.data);
             return new NoContentResult();
         }
 

--- a/sqe-api-server/Services/UserService.cs
+++ b/sqe-api-server/Services/UserService.cs
@@ -444,11 +444,6 @@ The Scripta Qumranica Electronica team</body></html>";
             if (!userId.HasValue)
                 throw new StandardExceptions.NoAuthorizationException();
 
-            // Make sure the string is not too long (we'll cap it at a million characters for now)
-            if (data.data.Length > 1000000)
-                throw new StandardExceptions.InputDataRuleViolationException(
-                    "data may not exceed 1,000,000 characters in the user personal data store");
-
             // Make sure the string is valid JSON (we don't use a guard in the database)
             try
             {

--- a/sqe-api-server/Startup.cs
+++ b/sqe-api-server/Startup.cs
@@ -178,6 +178,7 @@ namespace SQE.API.Server
                                 Type = SecuritySchemeType.ApiKey
                             }
                         );
+
                         c.AddSecurityRequirement(
                             new OpenApiSecurityRequirement
                             {
@@ -260,7 +261,10 @@ namespace SQE.API.Server
 
                 // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), 
                 // specifying the Swagger JSON endpoint.
-                app.UseSwaggerUI(c => { c.SwaggerEndpoint("/swagger/v1/swagger.json", "SQE API v1"); });
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "SQE API v1");
+                });
             }
 
             app.UseRouting();

--- a/sqe-api-test/ApiRequests/ArtefactRequests.cs
+++ b/sqe-api-test/ApiRequests/ArtefactRequests.cs
@@ -18,13 +18,23 @@ using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Delete
     {
+
+
         public class V1_Editions_EditionId_Artefacts_ArtefactId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
-            private readonly uint _artefactId;
             private readonly uint _editionId;
+            private readonly uint _artefactId;
+
+            public class Listeners
+            {
+                public ListenerMethods DeletedArtefact = ListenerMethods.DeletedArtefact;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Deletes the specified artefact
@@ -40,24 +50,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.DeletedArtefact, (DeletedArtefactIsNull, DeletedArtefactListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public DeleteDTO DeletedArtefact { get; private set; }
-
-            private void DeletedArtefactListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteDTO>("DeletedArtefact", receivedData => DeletedArtefact = receivedData);
-            }
-
-            private bool DeletedArtefactIsNull()
-            {
-                return DeletedArtefact == null;
-            }
+            private void DeletedArtefactListener(HubConnection signalrListener) => signalrListener.On<DeleteDTO>("DeletedArtefact", receivedData => DeletedArtefact = receivedData);
+            private bool DeletedArtefactIsNull() => DeletedArtefact == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/artefact-id", $"/{_artefactId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-id", $"/{_artefactId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -71,18 +70,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods DeletedArtefact = ListenerMethods.DeletedArtefact;
-            }
         }
 
         public class V1_Editions_EditionId_ArtefactGroups_ArtefactGroupId
-            : RequestObject<EmptyInput, DeleteDTO>
+        : RequestObject<EmptyInput, DeleteDTO>
         {
-            private readonly uint _artefactGroupId;
             private readonly uint _editionId;
+            private readonly uint _artefactGroupId;
+
+            public class Listeners
+            {
+                public ListenerMethods DeletedArtefactGroup = ListenerMethods.DeletedArtefactGroup;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Deletes the specified artefact group.
@@ -96,29 +96,16 @@ namespace SQE.ApiTest.ApiRequests
                 _editionId = editionId;
                 _artefactGroupId = artefactGroupId;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.DeletedArtefactGroup,
-                    (DeletedArtefactGroupIsNull, DeletedArtefactGroupListener));
+                _listenerDict.Add(ListenerMethods.DeletedArtefactGroup, (DeletedArtefactGroupIsNull, DeletedArtefactGroupListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public DeleteDTO DeletedArtefactGroup { get; private set; }
-
-            private void DeletedArtefactGroupListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteDTO>("DeletedArtefactGroup",
-                    receivedData => DeletedArtefactGroup = receivedData);
-            }
-
-            private bool DeletedArtefactGroupIsNull()
-            {
-                return DeletedArtefactGroup == null;
-            }
+            private void DeletedArtefactGroupListener(HubConnection signalrListener) => signalrListener.On<DeleteDTO>("DeletedArtefactGroup", receivedData => DeletedArtefactGroup = receivedData);
+            private bool DeletedArtefactGroupIsNull() => DeletedArtefactGroup == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/artefact-group-id", $"/{_artefactGroupId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-group-id", $"/{_artefactGroupId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -132,22 +119,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods DeletedArtefactGroup = ListenerMethods.DeletedArtefactGroup;
-            }
         }
     }
 
     public static partial class Get
     {
+
+
         public class V1_Editions_EditionId_Artefacts_ArtefactId
-            : RequestObject<EmptyInput, ArtefactDTO>
+        : RequestObject<EmptyInput, ArtefactDTO>
         {
-            private readonly uint _artefactId;
             private readonly uint _editionId;
+            private readonly uint _artefactId;
             private readonly List<string> _optional;
+
 
 
             /// <summary>
@@ -156,21 +141,21 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="artefactId">Unique Id of the desired artefact</param>
             /// <param name="editionId">Unique Id of the desired edition</param>
             /// <param name="optional">Add "masks" to include artefact polygons and "images" to include image data</param>
-            public V1_Editions_EditionId_Artefacts_ArtefactId(uint editionId, uint artefactId,
-                List<string> optional = null)
+            public V1_Editions_EditionId_Artefacts_ArtefactId(uint editionId, uint artefactId, List<string> optional = null)
 
             {
                 _editionId = editionId;
                 _artefactId = artefactId;
                 _optional = optional;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                           .Replace("/artefact-id", $"/{_artefactId.ToString()}")
-                       + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-id", $"/{_artefactId.ToString()}")
+                    + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -187,10 +172,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_Artefacts_ArtefactId_Rois
-            : RequestObject<EmptyInput, InterpretationRoiDTOList>
+        : RequestObject<EmptyInput, InterpretationRoiDTOList>
         {
-            private readonly uint _artefactId;
             private readonly uint _editionId;
+            private readonly uint _artefactId;
+
 
 
             /// <summary>
@@ -203,13 +189,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _artefactId = artefactId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/artefact-id", $"/{_artefactId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-id", $"/{_artefactId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -226,10 +213,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_Artefacts
-            : RequestObject<EmptyInput, ArtefactListDTO>
+        : RequestObject<EmptyInput, ArtefactListDTO>
         {
             private readonly uint _editionId;
             private readonly List<string> _optional;
+
 
 
             /// <summary>
@@ -242,13 +230,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _optional = optional;
+
             }
+
 
 
             protected override string HttpPath()
             {
                 return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                       + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
+                    + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -265,11 +255,12 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_Artefacts_ArtefactId_TextFragments
-            : RequestObject<EmptyInput, ArtefactTextFragmentMatchListDTO>
+        : RequestObject<EmptyInput, ArtefactTextFragmentMatchListDTO>
         {
-            private readonly uint _artefactId;
             private readonly uint _editionId;
+            private readonly uint _artefactId;
             private readonly List<string> _optional;
+
 
 
             /// <summary>
@@ -280,21 +271,21 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="editionId">Unique Id of the desired edition</param>
             /// <param name="artefactId">Unique Id of the desired artefact</param>
             /// <param name="optional">Add "suggested" to include possible matches suggested by the system</param>
-            public V1_Editions_EditionId_Artefacts_ArtefactId_TextFragments(uint editionId, uint artefactId,
-                List<string> optional = null)
+            public V1_Editions_EditionId_Artefacts_ArtefactId_TextFragments(uint editionId, uint artefactId, List<string> optional = null)
 
             {
                 _editionId = editionId;
                 _artefactId = artefactId;
                 _optional = optional;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                           .Replace("/artefact-id", $"/{_artefactId.ToString()}")
-                       + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-id", $"/{_artefactId.ToString()}")
+                    + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -311,9 +302,10 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_ArtefactGroups
-            : RequestObject<EmptyInput, ArtefactGroupListDTO>
+        : RequestObject<EmptyInput, ArtefactGroupListDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -325,7 +317,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -347,10 +341,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_ArtefactGroups_ArtefactGroupId
-            : RequestObject<EmptyInput, ArtefactGroupDTO>
+        : RequestObject<EmptyInput, ArtefactGroupDTO>
         {
-            private readonly uint _artefactGroupId;
             private readonly uint _editionId;
+            private readonly uint _artefactGroupId;
+
 
 
             /// <summary>
@@ -364,13 +359,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _artefactGroupId = artefactGroupId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/artefact-group-id", $"/{_artefactGroupId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-group-id", $"/{_artefactGroupId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -389,11 +385,19 @@ namespace SQE.ApiTest.ApiRequests
 
     public static partial class Post
     {
+
+
         public class V1_Editions_EditionId_Artefacts
-            : RequestObject<CreateArtefactDTO, ArtefactDTO>
+        : RequestObject<CreateArtefactDTO, ArtefactDTO>
         {
             private readonly uint _editionId;
             private readonly CreateArtefactDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedArtefact = ListenerMethods.CreatedArtefact;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates a new artefact with the provided data.
@@ -414,19 +418,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.CreatedArtefact, (CreatedArtefactIsNull, CreatedArtefactListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public ArtefactDTO CreatedArtefact { get; private set; }
-
-            private void CreatedArtefactListener(HubConnection signalrListener)
-            {
-                signalrListener.On<ArtefactDTO>("CreatedArtefact", receivedData => CreatedArtefact = receivedData);
-            }
-
-            private bool CreatedArtefactIsNull()
-            {
-                return CreatedArtefact == null;
-            }
+            private void CreatedArtefactListener(HubConnection signalrListener) => signalrListener.On<ArtefactDTO>("CreatedArtefact", receivedData => CreatedArtefact = receivedData);
+            private bool CreatedArtefactIsNull() => CreatedArtefact == null;
 
             protected override string HttpPath()
             {
@@ -444,18 +438,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedArtefact = ListenerMethods.CreatedArtefact;
-            }
         }
 
         public class V1_Editions_EditionId_Artefacts_BatchTransformation
-            : RequestObject<BatchUpdateArtefactPlacementDTO, BatchUpdatedArtefactTransformDTO>
+        : RequestObject<BatchUpdateArtefactPlacementDTO, BatchUpdatedArtefactTransformDTO>
         {
             private readonly uint _editionId;
             private readonly BatchUpdateArtefactPlacementDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedArtefact = ListenerMethods.UpdatedArtefact;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Updates the positional data for a batch of artefacts
@@ -463,8 +458,7 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="editionId">Unique Id of the desired edition</param>
             /// <param name="payload">A BatchUpdateArtefactTransformDTO with a list of the desired updates</param>
             /// <returns></returns>
-            public V1_Editions_EditionId_Artefacts_BatchTransformation(uint editionId,
-                BatchUpdateArtefactPlacementDTO payload)
+            public V1_Editions_EditionId_Artefacts_BatchTransformation(uint editionId, BatchUpdateArtefactPlacementDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
@@ -473,19 +467,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.UpdatedArtefact, (UpdatedArtefactIsNull, UpdatedArtefactListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public ArtefactDTO UpdatedArtefact { get; private set; }
-
-            private void UpdatedArtefactListener(HubConnection signalrListener)
-            {
-                signalrListener.On<ArtefactDTO>("UpdatedArtefact", receivedData => UpdatedArtefact = receivedData);
-            }
-
-            private bool UpdatedArtefactIsNull()
-            {
-                return UpdatedArtefact == null;
-            }
+            private void UpdatedArtefactListener(HubConnection signalrListener) => signalrListener.On<ArtefactDTO>("UpdatedArtefact", receivedData => UpdatedArtefact = receivedData);
+            private bool UpdatedArtefactIsNull() => UpdatedArtefact == null;
 
             protected override string HttpPath()
             {
@@ -503,18 +487,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedArtefact = ListenerMethods.UpdatedArtefact;
-            }
         }
 
         public class V1_Editions_EditionId_ArtefactGroups
-            : RequestObject<CreateArtefactGroupDTO, ArtefactGroupDTO>
+        : RequestObject<CreateArtefactGroupDTO, ArtefactGroupDTO>
         {
             private readonly uint _editionId;
             private readonly CreateArtefactGroupDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedArtefactGroup = ListenerMethods.CreatedArtefactGroup;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates a new artefact group with the submitted data.
@@ -530,24 +515,12 @@ namespace SQE.ApiTest.ApiRequests
                 _editionId = editionId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.CreatedArtefactGroup,
-                    (CreatedArtefactGroupIsNull, CreatedArtefactGroupListener));
+                _listenerDict.Add(ListenerMethods.CreatedArtefactGroup, (CreatedArtefactGroupIsNull, CreatedArtefactGroupListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public ArtefactGroupDTO CreatedArtefactGroup { get; private set; }
-
-            private void CreatedArtefactGroupListener(HubConnection signalrListener)
-            {
-                signalrListener.On<ArtefactGroupDTO>("CreatedArtefactGroup",
-                    receivedData => CreatedArtefactGroup = receivedData);
-            }
-
-            private bool CreatedArtefactGroupIsNull()
-            {
-                return CreatedArtefactGroup == null;
-            }
+            private void CreatedArtefactGroupListener(HubConnection signalrListener) => signalrListener.On<ArtefactGroupDTO>("CreatedArtefactGroup", receivedData => CreatedArtefactGroup = receivedData);
+            private bool CreatedArtefactGroupIsNull() => CreatedArtefactGroup == null;
 
             protected override string HttpPath()
             {
@@ -565,22 +538,25 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedArtefactGroup = ListenerMethods.CreatedArtefactGroup;
-            }
         }
     }
 
     public static partial class Put
     {
+
+
         public class V1_Editions_EditionId_Artefacts_ArtefactId
-            : RequestObject<UpdateArtefactDTO, ArtefactDTO>
+        : RequestObject<UpdateArtefactDTO, ArtefactDTO>
         {
-            private readonly uint _artefactId;
             private readonly uint _editionId;
+            private readonly uint _artefactId;
             private readonly UpdateArtefactDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedArtefact = ListenerMethods.UpdatedArtefact;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Updates the specified artefact.
@@ -597,8 +573,7 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="artefactId">Unique Id of the desired artefact</param>
             /// <param name="editionId">Unique Id of the desired edition</param>
             /// <param name="payload">An UpdateArtefactDTO with the desired alterations to the artefact</param>
-            public V1_Editions_EditionId_Artefacts_ArtefactId(uint editionId, uint artefactId,
-                UpdateArtefactDTO payload)
+            public V1_Editions_EditionId_Artefacts_ArtefactId(uint editionId, uint artefactId, UpdateArtefactDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
@@ -608,24 +583,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.UpdatedArtefact, (UpdatedArtefactIsNull, UpdatedArtefactListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public ArtefactDTO UpdatedArtefact { get; private set; }
-
-            private void UpdatedArtefactListener(HubConnection signalrListener)
-            {
-                signalrListener.On<ArtefactDTO>("UpdatedArtefact", receivedData => UpdatedArtefact = receivedData);
-            }
-
-            private bool UpdatedArtefactIsNull()
-            {
-                return UpdatedArtefact == null;
-            }
+            private void UpdatedArtefactListener(HubConnection signalrListener) => signalrListener.On<ArtefactDTO>("UpdatedArtefact", receivedData => UpdatedArtefact = receivedData);
+            private bool UpdatedArtefactIsNull() => UpdatedArtefact == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/artefact-id", $"/{_artefactId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-id", $"/{_artefactId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -639,19 +603,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedArtefact = ListenerMethods.UpdatedArtefact;
-            }
         }
 
         public class V1_Editions_EditionId_ArtefactGroups_ArtefactGroupId
-            : RequestObject<UpdateArtefactGroupDTO, ArtefactGroupDTO>
+        : RequestObject<UpdateArtefactGroupDTO, ArtefactGroupDTO>
         {
-            private readonly uint _artefactGroupId;
             private readonly uint _editionId;
+            private readonly uint _artefactGroupId;
             private readonly UpdateArtefactGroupDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedArtefactGroup = ListenerMethods.UpdatedArtefactGroup;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Updates the details of an artefact group.
@@ -662,43 +627,28 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="artefactGroupId">Id of the artefact group to be updated</param>
             /// <param name="payload">Parameters that the artefact group should be changed to</param>
             /// <returns></returns>
-            public V1_Editions_EditionId_ArtefactGroups_ArtefactGroupId(uint editionId, uint artefactGroupId,
-                UpdateArtefactGroupDTO payload)
+            public V1_Editions_EditionId_ArtefactGroups_ArtefactGroupId(uint editionId, uint artefactGroupId, UpdateArtefactGroupDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
                 _artefactGroupId = artefactGroupId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedArtefactGroup,
-                    (UpdatedArtefactGroupIsNull, UpdatedArtefactGroupListener));
+                _listenerDict.Add(ListenerMethods.UpdatedArtefactGroup, (UpdatedArtefactGroupIsNull, UpdatedArtefactGroupListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public ArtefactGroupDTO UpdatedArtefactGroup { get; private set; }
-
-            private void UpdatedArtefactGroupListener(HubConnection signalrListener)
-            {
-                signalrListener.On<ArtefactGroupDTO>("UpdatedArtefactGroup",
-                    receivedData => UpdatedArtefactGroup = receivedData);
-            }
-
-            private bool UpdatedArtefactGroupIsNull()
-            {
-                return UpdatedArtefactGroup == null;
-            }
+            private void UpdatedArtefactGroupListener(HubConnection signalrListener) => signalrListener.On<ArtefactGroupDTO>("UpdatedArtefactGroup", receivedData => UpdatedArtefactGroup = receivedData);
+            private bool UpdatedArtefactGroupIsNull() => UpdatedArtefactGroup == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/artefact-group-id", $"/{_artefactGroupId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/artefact-group-id", $"/{_artefactGroupId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR =>
-                    signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _artefactGroupId, _payload);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _artefactGroupId, _payload);
             }
 
             public override uint? GetEditionId()
@@ -707,11 +657,7 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedArtefactGroup = ListenerMethods.UpdatedArtefactGroup;
-            }
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/CatalogueRequests.cs
+++ b/sqe-api-test/ApiRequests/CatalogueRequests.cs
@@ -11,18 +11,24 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Delete
     {
+
+
         public class V1_Catalogue_ConfirmMatch_IaaEditionCatalogToTextFragmentId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
             private readonly uint _iaaEditionCatalogToTextFragmentId;
+
 
 
             /// <summary>
@@ -34,28 +40,34 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _iaaEditionCatalogToTextFragmentId = iaaEditionCatalogToTextFragmentId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/iaa-edition-catalog-to-text-fragment-id",
-                    $"/{_iaaEditionCatalogToTextFragmentId.ToString()}");
+                return RequestPath.Replace("/iaa-edition-catalog-to-text-fragment-id", $"/{_iaaEditionCatalogToTextFragmentId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _iaaEditionCatalogToTextFragmentId);
             }
+
+
         }
     }
 
     public static partial class Get
     {
+
+
         public class V1_Catalogue_ImagedObjects_ImagedObjectId_TextFragments
-            : RequestObject<EmptyInput, CatalogueMatchListDTO>
+        : RequestObject<EmptyInput, CatalogueMatchListDTO>
         {
             private readonly string _imagedObjectId;
+
 
 
             /// <summary>
@@ -66,24 +78,29 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _imagedObjectId = imagedObjectId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/imaged-object-id", $"/{_imagedObjectId}");
+                return RequestPath.Replace("/imaged-object-id", $"/{_imagedObjectId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _imagedObjectId);
             }
+
+
         }
 
         public class V1_Catalogue_TextFragments_TextFragmentId_ImagedObjects
-            : RequestObject<EmptyInput, CatalogueMatchListDTO>
+        : RequestObject<EmptyInput, CatalogueMatchListDTO>
         {
             private readonly uint _textFragmentId;
+
 
 
             /// <summary>
@@ -94,7 +111,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _textFragmentId = textFragmentId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -106,12 +125,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _textFragmentId);
             }
+
+
         }
 
         public class V1_Catalogue_Editions_EditionId_ImagedObjectTextFragmentMatches
-            : RequestObject<EmptyInput, CatalogueMatchListDTO>
+        : RequestObject<EmptyInput, CatalogueMatchListDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -122,7 +144,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -144,9 +168,10 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Catalogue_Manuscripts_ManuscriptId_ImagedObjectTextFragmentMatches
-            : RequestObject<EmptyInput, CatalogueMatchListDTO>
+        : RequestObject<EmptyInput, CatalogueMatchListDTO>
         {
             private readonly uint _manuscriptId;
+
 
 
             /// <summary>
@@ -157,7 +182,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _manuscriptId = manuscriptId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -169,15 +196,20 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _manuscriptId);
             }
+
+
         }
     }
 
     public static partial class Post
     {
+
+
         public class V1_Catalogue
-            : RequestObject<CatalogueMatchInputDTO, EmptyOutput>
+        : RequestObject<CatalogueMatchInputDTO, EmptyOutput>
         {
             private readonly CatalogueMatchInputDTO _payload;
+
 
 
             /// <summary>
@@ -189,7 +221,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -201,12 +235,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Catalogue_ConfirmMatch_IaaEditionCatalogToTextFragmentId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
             private readonly uint _iaaEditionCatalogToTextFragmentId;
+
 
 
             /// <summary>
@@ -218,19 +255,23 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _iaaEditionCatalogToTextFragmentId = iaaEditionCatalogToTextFragmentId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/iaa-edition-catalog-to-text-fragment-id",
-                    $"/{_iaaEditionCatalogToTextFragmentId.ToString()}");
+                return RequestPath.Replace("/iaa-edition-catalog-to-text-fragment-id", $"/{_iaaEditionCatalogToTextFragmentId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _iaaEditionCatalogToTextFragmentId);
             }
+
+
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/EditionRequests.cs
+++ b/sqe-api-test/ApiRequests/EditionRequests.cs
@@ -18,14 +18,24 @@ using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Delete
     {
+
+
         public class V1_Editions_EditionId
-            : RequestObject<EmptyInput, DeleteTokenDTO>
+        : RequestObject<EmptyInput, DeleteTokenDTO>
         {
             private readonly uint _editionId;
             private readonly List<string> _optional;
             private readonly string _token;
+
+            public class Listeners
+            {
+                public ListenerMethods DeletedEdition = ListenerMethods.DeletedEdition;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Provides details about the specified edition and all accessible alternate editions
@@ -43,25 +53,15 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.DeletedEdition, (DeletedEditionIsNull, DeletedEditionListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public DeleteTokenDTO DeletedEdition { get; private set; }
-
-            private void DeletedEditionListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteTokenDTO>("DeletedEdition", receivedData => DeletedEdition = receivedData);
-            }
-
-            private bool DeletedEditionIsNull()
-            {
-                return DeletedEdition == null;
-            }
+            private void DeletedEditionListener(HubConnection signalrListener) => signalrListener.On<DeleteTokenDTO>("DeletedEdition", receivedData => DeletedEdition = receivedData);
+            private bool DeletedEditionIsNull() => DeletedEdition == null;
 
             protected override string HttpPath()
             {
                 return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                       + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "")
-                       + (_token != null ? $"&token={_token}" : "");
+                    + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "")
+                    + (_token != null ? $"&token={_token}" : "");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -75,19 +75,34 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods DeletedEdition = ListenerMethods.DeletedEdition;
-            }
         }
     }
 
     public static partial class Get
     {
+
+
         public class V1_Editions_AdminShareRequests
-            : RequestObject<EmptyInput, AdminEditorRequestListDTO>
+        : RequestObject<EmptyInput, AdminEditorRequestListDTO>
         {
+
+
+
+
+            /// <summary>
+            ///     Get a list of requests issued by the current user for other users
+            ///     to become editors of a shared edition
+            /// </summary>
+            /// <returns></returns>
+            public V1_Editions_AdminShareRequests()
+
+            {
+
+
+            }
+
+
+
             protected override string HttpPath()
             {
                 return RequestPath;
@@ -97,11 +112,30 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString());
             }
+
+
         }
 
         public class V1_Editions_EditorInvitations
-            : RequestObject<EmptyInput, EditorInvitationListDTO>
+        : RequestObject<EmptyInput, EditorInvitationListDTO>
         {
+
+
+
+
+            /// <summary>
+            ///     Get a list of invitations issued to the current user to become an editor of a shared edition
+            /// </summary>
+            /// <returns></returns>
+            public V1_Editions_EditorInvitations()
+
+            {
+
+
+            }
+
+
+
             protected override string HttpPath()
             {
                 return RequestPath;
@@ -111,12 +145,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString());
             }
+
+
         }
 
         public class V1_Editions_EditionId
-            : RequestObject<EmptyInput, EditionGroupDTO>
+        : RequestObject<EmptyInput, EditionGroupDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -127,7 +164,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -149,8 +188,24 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions
-            : RequestObject<EmptyInput, EditionListDTO>
+        : RequestObject<EmptyInput, EditionListDTO>
         {
+
+
+
+
+            /// <summary>
+            ///     Provides a listing of all editions accessible to the current user
+            /// </summary>
+            public V1_Editions()
+
+            {
+
+
+            }
+
+
+
             protected override string HttpPath()
             {
                 return RequestPath;
@@ -160,12 +215,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString());
             }
+
+
         }
 
         public class V1_Editions_EditionId_ScriptCollection
-            : RequestObject<EmptyInput, EditionScriptCollectionDTO>
+        : RequestObject<EmptyInput, EditionScriptCollectionDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -177,7 +235,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -199,9 +259,10 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_ScriptLines
-            : RequestObject<EmptyInput, EditionScriptLinesDTO>
+        : RequestObject<EmptyInput, EditionScriptLinesDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -214,7 +275,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -238,11 +301,19 @@ namespace SQE.ApiTest.ApiRequests
 
     public static partial class Post
     {
+
+
         public class V1_Editions_EditionId_AddEditorRequest
-            : RequestObject<InviteEditorDTO, EmptyOutput>
+        : RequestObject<InviteEditorDTO, EmptyOutput>
         {
             private readonly uint _editionId;
             private readonly InviteEditorDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods RequestedEditor = ListenerMethods.RequestedEditor;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Adds an editor to the specified edition
@@ -258,20 +329,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.RequestedEditor, (RequestedEditorIsNull, RequestedEditorListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public EditorInvitationDTO RequestedEditor { get; private set; }
-
-            private void RequestedEditorListener(HubConnection signalrListener)
-            {
-                signalrListener.On<EditorInvitationDTO>("RequestedEditor",
-                    receivedData => RequestedEditor = receivedData);
-            }
-
-            private bool RequestedEditorIsNull()
-            {
-                return RequestedEditor == null;
-            }
+            private void RequestedEditorListener(HubConnection signalrListener) => signalrListener.On<EditorInvitationDTO>("RequestedEditor", receivedData => RequestedEditor = receivedData);
+            private bool RequestedEditorIsNull() => RequestedEditor == null;
 
             protected override string HttpPath()
             {
@@ -289,17 +349,18 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods RequestedEditor = ListenerMethods.RequestedEditor;
-            }
         }
 
         public class V1_Editions_ConfirmEditorship_Token
-            : RequestObject<EmptyInput, DetailedEditorRightsDTO>
+        : RequestObject<EmptyInput, DetailedEditorRightsDTO>
         {
             private readonly string _token;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedEditor = ListenerMethods.CreatedEditor;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Confirm addition of an editor to the specified edition
@@ -313,24 +374,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.CreatedEditor, (CreatedEditorIsNull, CreatedEditorListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public DetailedEditorRightsDTO CreatedEditor { get; private set; }
-
-            private void CreatedEditorListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DetailedEditorRightsDTO>("CreatedEditor",
-                    receivedData => CreatedEditor = receivedData);
-            }
-
-            private bool CreatedEditorIsNull()
-            {
-                return CreatedEditor == null;
-            }
+            private void CreatedEditorListener(HubConnection signalrListener) => signalrListener.On<DetailedEditorRightsDTO>("CreatedEditor", receivedData => CreatedEditor = receivedData);
+            private bool CreatedEditorIsNull() => CreatedEditor == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/token", $"/{_token}");
+                return RequestPath.Replace("/token", $"/{_token.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -338,17 +388,20 @@ namespace SQE.ApiTest.ApiRequests
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _token);
             }
 
-            public class Listeners
-            {
-                public ListenerMethods CreatedEditor = ListenerMethods.CreatedEditor;
-            }
+
         }
 
         public class V1_Editions_EditionId
-            : RequestObject<EditionCopyDTO, EditionDTO>
+        : RequestObject<EditionCopyDTO, EditionDTO>
         {
             private readonly uint _editionId;
             private readonly EditionCopyDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedEdition = ListenerMethods.CreatedEdition;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates a copy of the specified edition
@@ -364,19 +417,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.CreatedEdition, (CreatedEditionIsNull, CreatedEditionListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public EditionDTO CreatedEdition { get; private set; }
-
-            private void CreatedEditionListener(HubConnection signalrListener)
-            {
-                signalrListener.On<EditionDTO>("CreatedEdition", receivedData => CreatedEdition = receivedData);
-            }
-
-            private bool CreatedEditionIsNull()
-            {
-                return CreatedEdition == null;
-            }
+            private void CreatedEditionListener(HubConnection signalrListener) => signalrListener.On<EditionDTO>("CreatedEdition", receivedData => CreatedEdition = receivedData);
+            private bool CreatedEditionIsNull() => CreatedEdition == null;
 
             protected override string HttpPath()
             {
@@ -394,22 +437,25 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedEdition = ListenerMethods.CreatedEdition;
-            }
         }
     }
 
     public static partial class Put
     {
+
+
         public class V1_Editions_EditionId_Editors_EditorEmailId
-            : RequestObject<UpdateEditorRightsDTO, DetailedEditorRightsDTO>
+        : RequestObject<UpdateEditorRightsDTO, DetailedEditorRightsDTO>
         {
             private readonly uint _editionId;
             private readonly string _editorEmailId;
             private readonly UpdateEditorRightsDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedEditor = ListenerMethods.CreatedEditor;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Changes the rights for an editor of the specified edition
@@ -417,8 +463,7 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="editionId">Unique Id of the desired edition</param>
             /// <param name="editorEmailId">Email address of the editor whose permissions are being changed</param>
             /// <param name="payload">JSON object with the attributes of the new editor</param>
-            public V1_Editions_EditionId_Editors_EditorEmailId(uint editionId, string editorEmailId,
-                UpdateEditorRightsDTO payload)
+            public V1_Editions_EditionId_Editors_EditorEmailId(uint editionId, string editorEmailId, UpdateEditorRightsDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
@@ -428,25 +473,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.CreatedEditor, (CreatedEditorIsNull, CreatedEditorListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public DetailedEditorRightsDTO CreatedEditor { get; private set; }
-
-            private void CreatedEditorListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DetailedEditorRightsDTO>("CreatedEditor",
-                    receivedData => CreatedEditor = receivedData);
-            }
-
-            private bool CreatedEditorIsNull()
-            {
-                return CreatedEditor == null;
-            }
+            private void CreatedEditorListener(HubConnection signalrListener) => signalrListener.On<DetailedEditorRightsDTO>("CreatedEditor", receivedData => CreatedEditor = receivedData);
+            private bool CreatedEditorIsNull() => CreatedEditor == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/editor-email-id", $"/{_editorEmailId}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/editor-email-id", $"/{_editorEmailId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -460,18 +493,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedEditor = ListenerMethods.CreatedEditor;
-            }
         }
 
         public class V1_Editions_EditionId
-            : RequestObject<EditionUpdateRequestDTO, EditionDTO>
+        : RequestObject<EditionUpdateRequestDTO, EditionDTO>
         {
             private readonly uint _editionId;
             private readonly EditionUpdateRequestDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedEdition = ListenerMethods.UpdatedEdition;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Updates data for the specified edition
@@ -487,19 +521,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.UpdatedEdition, (UpdatedEditionIsNull, UpdatedEditionListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public EditionDTO UpdatedEdition { get; private set; }
-
-            private void UpdatedEditionListener(HubConnection signalrListener)
-            {
-                signalrListener.On<EditionDTO>("UpdatedEdition", receivedData => UpdatedEdition = receivedData);
-            }
-
-            private bool UpdatedEditionIsNull()
-            {
-                return UpdatedEdition == null;
-            }
+            private void UpdatedEditionListener(HubConnection signalrListener) => signalrListener.On<EditionDTO>("UpdatedEdition", receivedData => UpdatedEdition = receivedData);
+            private bool UpdatedEditionIsNull() => UpdatedEdition == null;
 
             protected override string HttpPath()
             {
@@ -517,11 +541,7 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedEdition = ListenerMethods.UpdatedEdition;
-            }
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/ImagedobjectRequests.cs
+++ b/sqe-api-test/ApiRequests/ImagedobjectRequests.cs
@@ -18,12 +18,17 @@ using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Get
     {
+
+
         public class V1_ImagedObjects_ImagedObjectId
-            : RequestObject<EmptyInput, SimpleImageListDTO>
+        : RequestObject<EmptyInput, SimpleImageListDTO>
         {
             private readonly string _imagedObjectId;
+
 
 
             /// <summary>
@@ -34,26 +39,31 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _imagedObjectId = imagedObjectId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/imaged-object-id", $"/{_imagedObjectId}");
+                return RequestPath.Replace("/imaged-object-id", $"/{_imagedObjectId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _imagedObjectId);
             }
+
+
         }
 
         public class V1_Editions_EditionId_ImagedObjects_ImagedObjectId
-            : RequestObject<EmptyInput, ImagedObjectDTO>
+        : RequestObject<EmptyInput, ImagedObjectDTO>
         {
             private readonly uint _editionId;
             private readonly string _imagedObjectId;
             private readonly List<string> _optional;
+
 
 
             /// <summary>
@@ -63,27 +73,26 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="editionId">Unique Id of the desired edition</param>
             /// <param name="imagedObjectId">Unique Id of the desired object from the imaging Institution</param>
             /// <param name="optional">Set 'artefacts' to receive related artefact data and 'masks' to include the artefact masks</param>
-            public V1_Editions_EditionId_ImagedObjects_ImagedObjectId(uint editionId, string imagedObjectId,
-                List<string> optional = null)
+            public V1_Editions_EditionId_ImagedObjects_ImagedObjectId(uint editionId, string imagedObjectId, List<string> optional = null)
 
             {
                 _editionId = editionId;
                 _imagedObjectId = imagedObjectId;
                 _optional = optional;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                           .Replace("/imaged-object-id", $"/{_imagedObjectId}")
-                       + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/imaged-object-id", $"/{_imagedObjectId.ToString()}")
+                    + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR =>
-                    signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _imagedObjectId, _optional);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _imagedObjectId, _optional);
             }
 
             public override uint? GetEditionId()
@@ -95,10 +104,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_ImagedObjects
-            : RequestObject<EmptyInput, ImagedObjectListDTO>
+        : RequestObject<EmptyInput, ImagedObjectListDTO>
         {
             private readonly uint _editionId;
             private readonly List<string> _optional;
+
 
 
             /// <summary>
@@ -112,13 +122,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _optional = optional;
+
             }
+
 
 
             protected override string HttpPath()
             {
                 return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                       + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
+                    + (_optional != null ? $"?optional={string.Join("&optional=", _optional)}" : "");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -135,8 +147,24 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_ImagedObjects_Institutions
-            : RequestObject<EmptyInput, ImageInstitutionListDTO>
+        : RequestObject<EmptyInput, ImageInstitutionListDTO>
         {
+
+
+
+
+            /// <summary>
+            ///     Provides a list of all institutional image providers.
+            /// </summary>
+            public V1_ImagedObjects_Institutions()
+
+            {
+
+
+            }
+
+
+
             protected override string HttpPath()
             {
                 return RequestPath;
@@ -146,12 +174,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString());
             }
+
+
         }
 
         public class V1_ImagedObjects_Institutions_InstitutionName
-            : RequestObject<EmptyInput, InstitutionalImageListDTO>
+        : RequestObject<EmptyInput, InstitutionalImageListDTO>
         {
             private readonly string _institutionName;
+
 
 
             /// <summary>
@@ -161,24 +192,29 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _institutionName = institutionName;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/institution-name", $"/{_institutionName}");
+                return RequestPath.Replace("/institution-name", $"/{_institutionName.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _institutionName);
             }
+
+
         }
 
         public class V1_ImagedObjects_ImagedObjectId_TextFragments
-            : RequestObject<EmptyInput, ImagedObjectTextFragmentMatchListDTO>
+        : RequestObject<EmptyInput, ImagedObjectTextFragmentMatchListDTO>
         {
             private readonly string _imagedObjectId;
+
 
 
             /// <summary>
@@ -190,18 +226,23 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _imagedObjectId = imagedObjectId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/imaged-object-id", $"/{_imagedObjectId}");
+                return RequestPath.Replace("/imaged-object-id", $"/{_imagedObjectId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _imagedObjectId);
             }
+
+
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/ListenerMethods.cs
+++ b/sqe-api-test/ApiRequests/ListenerMethods.cs
@@ -29,6 +29,6 @@ namespace SQE.ApiTest.ApiRequests
         DeletedAttribute,
         DeletedSignInterpretation,
         UpdatedAttribute,
-        CreatedTextFragment
+        CreatedTextFragment,
     }
 }

--- a/sqe-api-test/ApiRequests/RoiRequests.cs
+++ b/sqe-api-test/ApiRequests/RoiRequests.cs
@@ -11,19 +11,30 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Delete
     {
+
+
         public class V1_Editions_EditionId_Rois_RoiId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
             private readonly uint _editionId;
             private readonly uint _roiId;
+
+            public class Listeners
+            {
+                public ListenerMethods DeletedRoi = ListenerMethods.DeletedRoi;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Deletes a sign ROI from the given edition of a scroll
@@ -39,24 +50,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.DeletedRoi, (DeletedRoiIsNull, DeletedRoiListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public DeleteDTO DeletedRoi { get; private set; }
-
-            private void DeletedRoiListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteDTO>("DeletedRoi", receivedData => DeletedRoi = receivedData);
-            }
-
-            private bool DeletedRoiIsNull()
-            {
-                return DeletedRoi == null;
-            }
+            private void DeletedRoiListener(HubConnection signalrListener) => signalrListener.On<DeleteDTO>("DeletedRoi", receivedData => DeletedRoi = receivedData);
+            private bool DeletedRoiIsNull() => DeletedRoi == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/roi-id", $"/{_roiId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/roi-id", $"/{_roiId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -70,21 +70,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods DeletedRoi = ListenerMethods.DeletedRoi;
-            }
         }
     }
 
     public static partial class Get
     {
+
+
         public class V1_Editions_EditionId_Rois_RoiId
-            : RequestObject<EmptyInput, InterpretationRoiDTO>
+        : RequestObject<EmptyInput, InterpretationRoiDTO>
         {
             private readonly uint _editionId;
             private readonly uint _roiId;
+
 
 
             /// <summary>
@@ -97,13 +95,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _roiId = roiId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/roi-id", $"/{_roiId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/roi-id", $"/{_roiId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -122,11 +121,19 @@ namespace SQE.ApiTest.ApiRequests
 
     public static partial class Post
     {
+
+
         public class V1_Editions_EditionId_Rois
-            : RequestObject<SetInterpretationRoiDTO, InterpretationRoiDTO>
+        : RequestObject<SetInterpretationRoiDTO, InterpretationRoiDTO>
         {
             private readonly uint _editionId;
             private readonly SetInterpretationRoiDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedRoisBatch = ListenerMethods.CreatedRoisBatch;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates new sign ROI in the given edition of a scroll
@@ -142,20 +149,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.CreatedRoisBatch, (CreatedRoisBatchIsNull, CreatedRoisBatchListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public InterpretationRoiDTOList CreatedRoisBatch { get; private set; }
-
-            private void CreatedRoisBatchListener(HubConnection signalrListener)
-            {
-                signalrListener.On<InterpretationRoiDTOList>("CreatedRoisBatch",
-                    receivedData => CreatedRoisBatch = receivedData);
-            }
-
-            private bool CreatedRoisBatchIsNull()
-            {
-                return CreatedRoisBatch == null;
-            }
+            private void CreatedRoisBatchListener(HubConnection signalrListener) => signalrListener.On<InterpretationRoiDTOList>("CreatedRoisBatch", receivedData => CreatedRoisBatch = receivedData);
+            private bool CreatedRoisBatchIsNull() => CreatedRoisBatch == null;
 
             protected override string HttpPath()
             {
@@ -173,18 +169,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedRoisBatch = ListenerMethods.CreatedRoisBatch;
-            }
         }
 
         public class V1_Editions_EditionId_Rois_Batch
-            : RequestObject<SetInterpretationRoiDTOList, InterpretationRoiDTOList>
+        : RequestObject<SetInterpretationRoiDTOList, InterpretationRoiDTOList>
         {
             private readonly uint _editionId;
             private readonly SetInterpretationRoiDTOList _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods EditedRoisBatch = ListenerMethods.EditedRoisBatch;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates new sign ROI's in the given edition of a scroll
@@ -200,20 +197,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.EditedRoisBatch, (EditedRoisBatchIsNull, EditedRoisBatchListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public BatchEditRoiResponseDTO EditedRoisBatch { get; private set; }
-
-            private void EditedRoisBatchListener(HubConnection signalrListener)
-            {
-                signalrListener.On<BatchEditRoiResponseDTO>("EditedRoisBatch",
-                    receivedData => EditedRoisBatch = receivedData);
-            }
-
-            private bool EditedRoisBatchIsNull()
-            {
-                return EditedRoisBatch == null;
-            }
+            private void EditedRoisBatchListener(HubConnection signalrListener) => signalrListener.On<BatchEditRoiResponseDTO>("EditedRoisBatch", receivedData => EditedRoisBatch = receivedData);
+            private bool EditedRoisBatchIsNull() => EditedRoisBatch == null;
 
             protected override string HttpPath()
             {
@@ -231,18 +217,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
+        }
+
+        public class V1_Editions_EditionId_Rois_BatchEdit
+        : RequestObject<BatchEditRoiDTO, BatchEditRoiResponseDTO>
+        {
+            private readonly uint _editionId;
+            private readonly BatchEditRoiDTO _payload;
 
             public class Listeners
             {
                 public ListenerMethods EditedRoisBatch = ListenerMethods.EditedRoisBatch;
-            }
-        }
-
-        public class V1_Editions_EditionId_Rois_BatchEdit
-            : RequestObject<BatchEditRoiDTO, BatchEditRoiResponseDTO>
-        {
-            private readonly uint _editionId;
-            private readonly BatchEditRoiDTO _payload;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Processes a series of create/update/delete ROI requests in the given edition of a scroll
@@ -258,20 +245,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.EditedRoisBatch, (EditedRoisBatchIsNull, EditedRoisBatchListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public BatchEditRoiResponseDTO EditedRoisBatch { get; private set; }
-
-            private void EditedRoisBatchListener(HubConnection signalrListener)
-            {
-                signalrListener.On<BatchEditRoiResponseDTO>("EditedRoisBatch",
-                    receivedData => EditedRoisBatch = receivedData);
-            }
-
-            private bool EditedRoisBatchIsNull()
-            {
-                return EditedRoisBatch == null;
-            }
+            private void EditedRoisBatchListener(HubConnection signalrListener) => signalrListener.On<BatchEditRoiResponseDTO>("EditedRoisBatch", receivedData => EditedRoisBatch = receivedData);
+            private bool EditedRoisBatchIsNull() => EditedRoisBatch == null;
 
             protected override string HttpPath()
             {
@@ -289,22 +265,25 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods EditedRoisBatch = ListenerMethods.EditedRoisBatch;
-            }
         }
     }
 
     public static partial class Put
     {
+
+
         public class V1_Editions_EditionId_Rois_RoiId
-            : RequestObject<SetInterpretationRoiDTO, UpdatedInterpretationRoiDTO>
+        : RequestObject<SetInterpretationRoiDTO, UpdatedInterpretationRoiDTO>
         {
             private readonly uint _editionId;
-            private readonly SetInterpretationRoiDTO _payload;
             private readonly uint _roiId;
+            private readonly SetInterpretationRoiDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods EditedRoisBatch = ListenerMethods.EditedRoisBatch;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Update an existing sign ROI in the given edition of a scroll
@@ -322,25 +301,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.EditedRoisBatch, (EditedRoisBatchIsNull, EditedRoisBatchListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public BatchEditRoiResponseDTO EditedRoisBatch { get; private set; }
-
-            private void EditedRoisBatchListener(HubConnection signalrListener)
-            {
-                signalrListener.On<BatchEditRoiResponseDTO>("EditedRoisBatch",
-                    receivedData => EditedRoisBatch = receivedData);
-            }
-
-            private bool EditedRoisBatchIsNull()
-            {
-                return EditedRoisBatch == null;
-            }
+            private void EditedRoisBatchListener(HubConnection signalrListener) => signalrListener.On<BatchEditRoiResponseDTO>("EditedRoisBatch", receivedData => EditedRoisBatch = receivedData);
+            private bool EditedRoisBatchIsNull() => EditedRoisBatch == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/roi-id", $"/{_roiId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/roi-id", $"/{_roiId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -354,18 +321,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods EditedRoisBatch = ListenerMethods.EditedRoisBatch;
-            }
         }
 
         public class V1_Editions_EditionId_Rois_Batch
-            : RequestObject<UpdateInterpretationRoiDTOList, UpdatedInterpretationRoiDTOList>
+        : RequestObject<UpdateInterpretationRoiDTOList, UpdatedInterpretationRoiDTOList>
         {
             private readonly uint _editionId;
             private readonly UpdateInterpretationRoiDTOList _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedRoisBatch = ListenerMethods.UpdatedRoisBatch;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Update existing sign ROI's in the given edition of a scroll
@@ -381,20 +349,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.UpdatedRoisBatch, (UpdatedRoisBatchIsNull, UpdatedRoisBatchListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public UpdatedInterpretationRoiDTOList UpdatedRoisBatch { get; private set; }
-
-            private void UpdatedRoisBatchListener(HubConnection signalrListener)
-            {
-                signalrListener.On<UpdatedInterpretationRoiDTOList>("UpdatedRoisBatch",
-                    receivedData => UpdatedRoisBatch = receivedData);
-            }
-
-            private bool UpdatedRoisBatchIsNull()
-            {
-                return UpdatedRoisBatch == null;
-            }
+            private void UpdatedRoisBatchListener(HubConnection signalrListener) => signalrListener.On<UpdatedInterpretationRoiDTOList>("UpdatedRoisBatch", receivedData => UpdatedRoisBatch = receivedData);
+            private bool UpdatedRoisBatchIsNull() => UpdatedRoisBatch == null;
 
             protected override string HttpPath()
             {
@@ -412,11 +369,7 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedRoisBatch = ListenerMethods.UpdatedRoisBatch;
-            }
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/SigninterpretationRequests.cs
+++ b/sqe-api-test/ApiRequests/SigninterpretationRequests.cs
@@ -11,19 +11,30 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Delete
     {
+
+
         public class V1_Editions_EditionId_SignInterpretationsAttributes_AttributeId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
-            private readonly uint _attributeId;
             private readonly uint _editionId;
+            private readonly uint _attributeId;
+
+            public class Listeners
+            {
+                public ListenerMethods DeletedAttribute = ListenerMethods.DeletedAttribute;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Delete an attribute from an edition
@@ -41,24 +52,13 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.DeletedAttribute, (DeletedAttributeIsNull, DeletedAttributeListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public DeleteDTO DeletedAttribute { get; private set; }
-
-            private void DeletedAttributeListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteDTO>("DeletedAttribute", receivedData => DeletedAttribute = receivedData);
-            }
-
-            private bool DeletedAttributeIsNull()
-            {
-                return DeletedAttribute == null;
-            }
+            private void DeletedAttributeListener(HubConnection signalrListener) => signalrListener.On<DeleteDTO>("DeletedAttribute", receivedData => DeletedAttribute = receivedData);
+            private bool DeletedAttributeIsNull() => DeletedAttribute == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/attribute-id", $"/{_attributeId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/attribute-id", $"/{_attributeId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -72,18 +72,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods DeletedAttribute = ListenerMethods.DeletedAttribute;
-            }
         }
 
         public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
             private readonly uint _editionId;
             private readonly uint _signInterpretationId;
+
+            public class Listeners
+            {
+                public ListenerMethods DeletedSignInterpretation = ListenerMethods.DeletedSignInterpretation;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Deletes the sign interpretation in the route. The endpoint automatically manages the sign stream
@@ -92,36 +93,22 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="editionId">ID of the edition being changed</param>
             /// <param name="signInterpretationId">ID of the sign interpretation being deleted</param>
             /// <returns>Ok or Error</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId(uint editionId,
-                uint signInterpretationId)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId(uint editionId, uint signInterpretationId)
 
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.DeletedSignInterpretation,
-                    (DeletedSignInterpretationIsNull, DeletedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.DeletedSignInterpretation, (DeletedSignInterpretationIsNull, DeletedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public DeleteDTO DeletedSignInterpretation { get; private set; }
-
-            private void DeletedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteDTO>("DeletedSignInterpretation",
-                    receivedData => DeletedSignInterpretation = receivedData);
-            }
-
-            private bool DeletedSignInterpretationIsNull()
-            {
-                return DeletedSignInterpretation == null;
-            }
+            private void DeletedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<DeleteDTO>("DeletedSignInterpretation", receivedData => DeletedSignInterpretation = receivedData);
+            private bool DeletedSignInterpretationIsNull() => DeletedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -135,19 +122,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods DeletedSignInterpretation = ListenerMethods.DeletedSignInterpretation;
-            }
         }
 
         public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId
-            : RequestObject<EmptyInput, EmptyOutput>
+        : RequestObject<EmptyInput, EmptyOutput>
         {
-            private readonly uint _attributeValueId;
             private readonly uint _editionId;
             private readonly uint _signInterpretationId;
+            private readonly uint _attributeValueId;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     This deletes the specified attribute value from the specified sign interpretation.
@@ -156,44 +144,28 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="signInterpretationId">ID of the sign interpretation being altered</param>
             /// <param name="attributeValueId">Id of the attribute being removed</param>
             /// <returns>Ok or Error</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId(
-                uint editionId, uint signInterpretationId, uint attributeValueId)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId(uint editionId, uint signInterpretationId, uint attributeValueId)
 
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
                 _attributeValueId = attributeValueId;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation,
-                    (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation, (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationDTO UpdatedSignInterpretation { get; private set; }
-
-            private void UpdatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation",
-                    receivedData => UpdatedSignInterpretation = receivedData);
-            }
-
-            private bool UpdatedSignInterpretationIsNull()
-            {
-                return UpdatedSignInterpretation == null;
-            }
+            private void UpdatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation", receivedData => UpdatedSignInterpretation = receivedData);
+            private bool UpdatedSignInterpretationIsNull() => UpdatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}")
-                    .Replace("/attribute-value-id", $"/{_attributeValueId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}").Replace("/attribute-value-id", $"/{_attributeValueId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId,
-                    _attributeValueId);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _attributeValueId);
             }
 
             public override uint? GetEditionId()
@@ -202,20 +174,18 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
-            }
         }
     }
 
     public static partial class Get
     {
+
+
         public class V1_Editions_EditionId_SignInterpretationsAttributes
-            : RequestObject<EmptyInput, AttributeListDTO>
+        : RequestObject<EmptyInput, AttributeListDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -227,7 +197,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -249,10 +221,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId
-            : RequestObject<EmptyInput, SignInterpretationDTO>
+        : RequestObject<EmptyInput, SignInterpretationDTO>
         {
             private readonly uint _editionId;
             private readonly uint _signInterpretationId;
+
 
 
             /// <summary>
@@ -261,19 +234,19 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="editionId">The ID of the edition being searched</param>
             /// <param name="signInterpretationId">The desired sign interpretation id</param>
             /// <returns>The details of the desired sign interpretation</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId(uint editionId,
-                uint signInterpretationId)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId(uint editionId, uint signInterpretationId)
 
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -292,11 +265,19 @@ namespace SQE.ApiTest.ApiRequests
 
     public static partial class Post
     {
+
+
         public class V1_Editions_EditionId_SignInterpretationsAttributes
-            : RequestObject<CreateAttributeDTO, AttributeDTO>
+        : RequestObject<CreateAttributeDTO, AttributeDTO>
         {
             private readonly uint _editionId;
             private readonly CreateAttributeDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedAttribute = ListenerMethods.CreatedAttribute;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Create a new attribute for an edition
@@ -313,19 +294,9 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.CreatedAttribute, (CreatedAttributeIsNull, CreatedAttributeListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public AttributeDTO CreatedAttribute { get; private set; }
-
-            private void CreatedAttributeListener(HubConnection signalrListener)
-            {
-                signalrListener.On<AttributeDTO>("CreatedAttribute", receivedData => CreatedAttribute = receivedData);
-            }
-
-            private bool CreatedAttributeIsNull()
-            {
-                return CreatedAttribute == null;
-            }
+            private void CreatedAttributeListener(HubConnection signalrListener) => signalrListener.On<AttributeDTO>("CreatedAttribute", receivedData => CreatedAttribute = receivedData);
+            private bool CreatedAttributeIsNull() => CreatedAttribute == null;
 
             protected override string HttpPath()
             {
@@ -343,18 +314,19 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedAttribute = ListenerMethods.CreatedAttribute;
-            }
         }
 
         public class V1_Editions_EditionId_SignInterpretations
-            : RequestObject<SignInterpretationCreateDTO, SignInterpretationListDTO>
+        : RequestObject<SignInterpretationCreateDTO, SignInterpretationListDTO>
         {
             private readonly uint _editionId;
             private readonly SignInterpretationCreateDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedSignInterpretation = ListenerMethods.CreatedSignInterpretation;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates a new sign interpretation
@@ -368,24 +340,12 @@ namespace SQE.ApiTest.ApiRequests
                 _editionId = editionId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.CreatedSignInterpretation,
-                    (CreatedSignInterpretationIsNull, CreatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.CreatedSignInterpretation, (CreatedSignInterpretationIsNull, CreatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationListDTO CreatedSignInterpretation { get; private set; }
-
-            private void CreatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationListDTO>("CreatedSignInterpretation",
-                    receivedData => CreatedSignInterpretation = receivedData);
-            }
-
-            private bool CreatedSignInterpretationIsNull()
-            {
-                return CreatedSignInterpretation == null;
-            }
+            private void CreatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationListDTO>("CreatedSignInterpretation", receivedData => CreatedSignInterpretation = receivedData);
+            private bool CreatedSignInterpretationIsNull() => CreatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
@@ -403,19 +363,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedSignInterpretation = ListenerMethods.CreatedSignInterpretation;
-            }
         }
 
         public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_LinkTo_NextSignInterpretationId
-            : RequestObject<EmptyInput, SignInterpretationDTO>
+        : RequestObject<EmptyInput, SignInterpretationDTO>
         {
             private readonly uint _editionId;
-            private readonly uint _nextSignInterpretationId;
             private readonly uint _signInterpretationId;
+            private readonly uint _nextSignInterpretationId;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Links two sign interpretations in the edition's sign stream
@@ -424,44 +385,28 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="signInterpretationId">The sign interpretation to be linked to the nextSignInterpretationId</param>
             /// <param name="nextSignInterpretationId">The sign interpretation to become the new next sign interpretation</param>
             /// <returns>The updated sign interpretation</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_LinkTo_NextSignInterpretationId(
-                uint editionId, uint signInterpretationId, uint nextSignInterpretationId)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_LinkTo_NextSignInterpretationId(uint editionId, uint signInterpretationId, uint nextSignInterpretationId)
 
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
                 _nextSignInterpretationId = nextSignInterpretationId;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation,
-                    (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation, (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationDTO UpdatedSignInterpretation { get; private set; }
-
-            private void UpdatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation",
-                    receivedData => UpdatedSignInterpretation = receivedData);
-            }
-
-            private bool UpdatedSignInterpretationIsNull()
-            {
-                return UpdatedSignInterpretation == null;
-            }
+            private void UpdatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation", receivedData => UpdatedSignInterpretation = receivedData);
+            private bool UpdatedSignInterpretationIsNull() => UpdatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}")
-                    .Replace("/next-sign-interpretation-id", $"/{_nextSignInterpretationId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}").Replace("/next-sign-interpretation-id", $"/{_nextSignInterpretationId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId,
-                    _nextSignInterpretationId);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _nextSignInterpretationId);
             }
 
             public override uint? GetEditionId()
@@ -470,19 +415,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
+        }
+
+        public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_UnlinkFrom_NextSignInterpretationId
+        : RequestObject<EmptyInput, SignInterpretationDTO>
+        {
+            private readonly uint _editionId;
+            private readonly uint _signInterpretationId;
+            private readonly uint _nextSignInterpretationId;
 
             public class Listeners
             {
                 public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
-            }
-        }
-
-        public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_UnlinkFrom_NextSignInterpretationId
-            : RequestObject<EmptyInput, SignInterpretationDTO>
-        {
-            private readonly uint _editionId;
-            private readonly uint _nextSignInterpretationId;
-            private readonly uint _signInterpretationId;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Links two sign interpretations in the edition's sign stream
@@ -491,44 +437,28 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="signInterpretationId">The sign interpretation to be unlinked from the nextSignInterpretationId</param>
             /// <param name="nextSignInterpretationId">The sign interpretation to removed as next sign interpretation</param>
             /// <returns>The updated sign interpretation</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_UnlinkFrom_NextSignInterpretationId(
-                uint editionId, uint signInterpretationId, uint nextSignInterpretationId)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_UnlinkFrom_NextSignInterpretationId(uint editionId, uint signInterpretationId, uint nextSignInterpretationId)
 
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
                 _nextSignInterpretationId = nextSignInterpretationId;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation,
-                    (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation, (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationDTO UpdatedSignInterpretation { get; private set; }
-
-            private void UpdatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation",
-                    receivedData => UpdatedSignInterpretation = receivedData);
-            }
-
-            private bool UpdatedSignInterpretationIsNull()
-            {
-                return UpdatedSignInterpretation == null;
-            }
+            private void UpdatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation", receivedData => UpdatedSignInterpretation = receivedData);
+            private bool UpdatedSignInterpretationIsNull() => UpdatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}")
-                    .Replace("/next-sign-interpretation-id", $"/{_nextSignInterpretationId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}").Replace("/next-sign-interpretation-id", $"/{_nextSignInterpretationId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId,
-                    _nextSignInterpretationId);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _nextSignInterpretationId);
             }
 
             public override uint? GetEditionId()
@@ -537,19 +467,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
+        }
+
+        public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes
+        : RequestObject<InterpretationAttributeCreateDTO, SignInterpretationDTO>
+        {
+            private readonly uint _editionId;
+            private readonly uint _signInterpretationId;
+            private readonly InterpretationAttributeCreateDTO _payload;
 
             public class Listeners
             {
                 public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
-            }
-        }
-
-        public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes
-            : RequestObject<InterpretationAttributeCreateDTO, SignInterpretationDTO>
-        {
-            private readonly uint _editionId;
-            private readonly InterpretationAttributeCreateDTO _payload;
-            private readonly uint _signInterpretationId;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     This adds a new attribute to the specified sign interpretation.
@@ -558,43 +489,28 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="signInterpretationId">ID of the sign interpretation for adding a new attribute</param>
             /// <param name="newSignInterpretationAttributes">Details of the attribute to be added</param>
             /// <returns>The updated sign interpretation</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes(uint editionId,
-                uint signInterpretationId, InterpretationAttributeCreateDTO payload)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes(uint editionId, uint signInterpretationId, InterpretationAttributeCreateDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation,
-                    (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation, (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationDTO UpdatedSignInterpretation { get; private set; }
-
-            private void UpdatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation",
-                    receivedData => UpdatedSignInterpretation = receivedData);
-            }
-
-            private bool UpdatedSignInterpretationIsNull()
-            {
-                return UpdatedSignInterpretation == null;
-            }
+            private void UpdatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation", receivedData => UpdatedSignInterpretation = receivedData);
+            private bool UpdatedSignInterpretationIsNull() => UpdatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR =>
-                    signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _payload);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _payload);
             }
 
             public override uint? GetEditionId()
@@ -603,22 +519,27 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
-            }
         }
     }
 
     public static partial class Put
     {
+
+
         public class V1_Editions_EditionId_SignInterpretationsAttributes_AttributeId
-            : RequestObject<UpdateAttributeDTO, AttributeDTO>
+        : RequestObject<UpdateAttributeDTO, AttributeDTO>
         {
-            private readonly uint _attributeId;
             private readonly uint _editionId;
+            private readonly uint _attributeId;
             private readonly UpdateAttributeDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedAttribute = ListenerMethods.CreatedAttribute;
+                public ListenerMethods DeletedAttribute = ListenerMethods.DeletedAttribute;
+                public ListenerMethods UpdatedAttribute = ListenerMethods.UpdatedAttribute;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Change the details of an attribute in an edition
@@ -628,8 +549,7 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="updatedAttribute">The details of the updated attribute</param>
             /// <returns></returns>
             /// <exception cref="NotImplementedException"></exception>
-            public V1_Editions_EditionId_SignInterpretationsAttributes_AttributeId(uint editionId, uint attributeId,
-                UpdateAttributeDTO payload)
+            public V1_Editions_EditionId_SignInterpretationsAttributes_AttributeId(uint editionId, uint attributeId, UpdateAttributeDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
@@ -641,46 +561,19 @@ namespace SQE.ApiTest.ApiRequests
                 _listenerDict.Add(ListenerMethods.UpdatedAttribute, (UpdatedAttributeIsNull, UpdatedAttributeListener));
             }
 
-            public Listeners AvailableListeners { get; }
-
             public AttributeDTO CreatedAttribute { get; private set; }
+            private void CreatedAttributeListener(HubConnection signalrListener) => signalrListener.On<AttributeDTO>("CreatedAttribute", receivedData => CreatedAttribute = receivedData);
+            private bool CreatedAttributeIsNull() => CreatedAttribute == null;
             public DeleteDTO DeletedAttribute { get; private set; }
+            private void DeletedAttributeListener(HubConnection signalrListener) => signalrListener.On<DeleteDTO>("DeletedAttribute", receivedData => DeletedAttribute = receivedData);
+            private bool DeletedAttributeIsNull() => DeletedAttribute == null;
             public AttributeDTO UpdatedAttribute { get; private set; }
-
-            private void CreatedAttributeListener(HubConnection signalrListener)
-            {
-                signalrListener.On<AttributeDTO>("CreatedAttribute", receivedData => CreatedAttribute = receivedData);
-            }
-
-            private bool CreatedAttributeIsNull()
-            {
-                return CreatedAttribute == null;
-            }
-
-            private void DeletedAttributeListener(HubConnection signalrListener)
-            {
-                signalrListener.On<DeleteDTO>("DeletedAttribute", receivedData => DeletedAttribute = receivedData);
-            }
-
-            private bool DeletedAttributeIsNull()
-            {
-                return DeletedAttribute == null;
-            }
-
-            private void UpdatedAttributeListener(HubConnection signalrListener)
-            {
-                signalrListener.On<AttributeDTO>("UpdatedAttribute", receivedData => UpdatedAttribute = receivedData);
-            }
-
-            private bool UpdatedAttributeIsNull()
-            {
-                return UpdatedAttribute == null;
-            }
+            private void UpdatedAttributeListener(HubConnection signalrListener) => signalrListener.On<AttributeDTO>("UpdatedAttribute", receivedData => UpdatedAttribute = receivedData);
+            private bool UpdatedAttributeIsNull() => UpdatedAttribute == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/attribute-id", $"/{_attributeId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/attribute-id", $"/{_attributeId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -694,21 +587,20 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedAttribute = ListenerMethods.CreatedAttribute;
-                public ListenerMethods DeletedAttribute = ListenerMethods.DeletedAttribute;
-                public ListenerMethods UpdatedAttribute = ListenerMethods.UpdatedAttribute;
-            }
         }
 
         public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Commentary
-            : RequestObject<CommentaryCreateDTO, SignInterpretationDTO>
+        : RequestObject<CommentaryCreateDTO, SignInterpretationDTO>
         {
             private readonly uint _editionId;
-            private readonly CommentaryCreateDTO _payload;
             private readonly uint _signInterpretationId;
+            private readonly CommentaryCreateDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Updates the commentary of a sign interpretation
@@ -717,43 +609,28 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="signInterpretationId">ID of the sign interpretation whose commentary is being changed</param>
             /// <param name="commentary">The new commentary for the sign interpretation</param>
             /// <returns>Ok or Error</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Commentary(uint editionId,
-                uint signInterpretationId, CommentaryCreateDTO payload)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Commentary(uint editionId, uint signInterpretationId, CommentaryCreateDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
                 _signInterpretationId = signInterpretationId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation,
-                    (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation, (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationDTO UpdatedSignInterpretation { get; private set; }
-
-            private void UpdatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation",
-                    receivedData => UpdatedSignInterpretation = receivedData);
-            }
-
-            private bool UpdatedSignInterpretationIsNull()
-            {
-                return UpdatedSignInterpretation == null;
-            }
+            private void UpdatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation", receivedData => UpdatedSignInterpretation = receivedData);
+            private bool UpdatedSignInterpretationIsNull() => UpdatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR =>
-                    signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _payload);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _payload);
             }
 
             public override uint? GetEditionId()
@@ -762,20 +639,21 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
+        }
+
+        public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId
+        : RequestObject<InterpretationAttributeCreateDTO, SignInterpretationDTO>
+        {
+            private readonly uint _editionId;
+            private readonly uint _signInterpretationId;
+            private readonly uint _attributeValueId;
+            private readonly InterpretationAttributeCreateDTO _payload;
 
             public class Listeners
             {
                 public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
-            }
-        }
-
-        public class V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId
-            : RequestObject<InterpretationAttributeCreateDTO, SignInterpretationDTO>
-        {
-            private readonly uint _attributeValueId;
-            private readonly uint _editionId;
-            private readonly InterpretationAttributeCreateDTO _payload;
-            private readonly uint _signInterpretationId;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     This changes the values of the specified sign interpretation attribute,
@@ -786,9 +664,7 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="attributeValueId">Id of the attribute value to be altered</param>
             /// <param name="alteredSignInterpretationAttribute">New details of the attribute</param>
             /// <returns>The updated sign interpretation</returns>
-            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId(
-                uint editionId, uint signInterpretationId, uint attributeValueId,
-                InterpretationAttributeCreateDTO payload)
+            public V1_Editions_EditionId_SignInterpretations_SignInterpretationId_Attributes_AttributeValueId(uint editionId, uint signInterpretationId, uint attributeValueId, InterpretationAttributeCreateDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
@@ -796,36 +672,21 @@ namespace SQE.ApiTest.ApiRequests
                 _attributeValueId = attributeValueId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation,
-                    (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
+                _listenerDict.Add(ListenerMethods.UpdatedSignInterpretation, (UpdatedSignInterpretationIsNull, UpdatedSignInterpretationListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public SignInterpretationDTO UpdatedSignInterpretation { get; private set; }
-
-            private void UpdatedSignInterpretationListener(HubConnection signalrListener)
-            {
-                signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation",
-                    receivedData => UpdatedSignInterpretation = receivedData);
-            }
-
-            private bool UpdatedSignInterpretationIsNull()
-            {
-                return UpdatedSignInterpretation == null;
-            }
+            private void UpdatedSignInterpretationListener(HubConnection signalrListener) => signalrListener.On<SignInterpretationDTO>("UpdatedSignInterpretation", receivedData => UpdatedSignInterpretation = receivedData);
+            private bool UpdatedSignInterpretationIsNull() => UpdatedSignInterpretation == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}")
-                    .Replace("/attribute-value-id", $"/{_attributeValueId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/sign-interpretation-id", $"/{_signInterpretationId.ToString()}").Replace("/attribute-value-id", $"/{_attributeValueId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
             {
-                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId,
-                    _attributeValueId, _payload);
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _editionId, _signInterpretationId, _attributeValueId, _payload);
             }
 
             public override uint? GetEditionId()
@@ -834,11 +695,7 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods UpdatedSignInterpretation = ListenerMethods.UpdatedSignInterpretation;
-            }
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/TextRequests.cs
+++ b/sqe-api-test/ApiRequests/TextRequests.cs
@@ -11,18 +11,24 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Get
     {
+
+
         public class V1_Editions_EditionId_TextFragments
-            : RequestObject<EmptyInput, TextFragmentDataListDTO>
+        : RequestObject<EmptyInput, TextFragmentDataListDTO>
         {
             private readonly uint _editionId;
+
 
 
             /// <summary>
@@ -34,7 +40,9 @@ namespace SQE.ApiTest.ApiRequests
 
             {
                 _editionId = editionId;
+
             }
+
 
 
             protected override string HttpPath()
@@ -56,10 +64,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_TextFragments_TextFragmentId_Artefacts
-            : RequestObject<EmptyInput, ArtefactDataListDTO>
+        : RequestObject<EmptyInput, ArtefactDataListDTO>
         {
             private readonly uint _editionId;
             private readonly uint _textFragmentId;
+
 
 
             /// <summary>
@@ -73,13 +82,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _textFragmentId = textFragmentId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -96,10 +106,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_TextFragments_TextFragmentId_Lines
-            : RequestObject<EmptyInput, LineDataListDTO>
+        : RequestObject<EmptyInput, LineDataListDTO>
         {
             private readonly uint _editionId;
             private readonly uint _textFragmentId;
+
 
 
             /// <summary>
@@ -113,13 +124,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _textFragmentId = textFragmentId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -136,10 +148,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_TextFragments_TextFragmentId
-            : RequestObject<EmptyInput, TextEditionDTO>
+        : RequestObject<EmptyInput, TextEditionDTO>
         {
             private readonly uint _editionId;
             private readonly uint _textFragmentId;
+
 
 
             /// <summary>
@@ -156,13 +169,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _textFragmentId = textFragmentId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -179,10 +193,11 @@ namespace SQE.ApiTest.ApiRequests
         }
 
         public class V1_Editions_EditionId_Lines_LineId
-            : RequestObject<EmptyInput, LineTextDTO>
+        : RequestObject<EmptyInput, LineTextDTO>
         {
             private readonly uint _editionId;
             private readonly uint _lineId;
+
 
 
             /// <summary>
@@ -199,13 +214,14 @@ namespace SQE.ApiTest.ApiRequests
             {
                 _editionId = editionId;
                 _lineId = lineId;
+
             }
+
 
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/line-id", $"/{_lineId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/line-id", $"/{_lineId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -224,11 +240,19 @@ namespace SQE.ApiTest.ApiRequests
 
     public static partial class Post
     {
+
+
         public class V1_Editions_EditionId_TextFragments
-            : RequestObject<CreateTextFragmentDTO, TextFragmentDataDTO>
+        : RequestObject<CreateTextFragmentDTO, TextFragmentDataDTO>
         {
             private readonly uint _editionId;
             private readonly CreateTextFragmentDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedTextFragment = ListenerMethods.CreatedTextFragment;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Creates a new text fragment in the given edition of a scroll
@@ -241,24 +265,12 @@ namespace SQE.ApiTest.ApiRequests
                 _editionId = editionId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.CreatedTextFragment,
-                    (CreatedTextFragmentIsNull, CreatedTextFragmentListener));
+                _listenerDict.Add(ListenerMethods.CreatedTextFragment, (CreatedTextFragmentIsNull, CreatedTextFragmentListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public TextFragmentDataDTO CreatedTextFragment { get; private set; }
-
-            private void CreatedTextFragmentListener(HubConnection signalrListener)
-            {
-                signalrListener.On<TextFragmentDataDTO>("CreatedTextFragment",
-                    receivedData => CreatedTextFragment = receivedData);
-            }
-
-            private bool CreatedTextFragmentIsNull()
-            {
-                return CreatedTextFragment == null;
-            }
+            private void CreatedTextFragmentListener(HubConnection signalrListener) => signalrListener.On<TextFragmentDataDTO>("CreatedTextFragment", receivedData => CreatedTextFragment = receivedData);
+            private bool CreatedTextFragmentIsNull() => CreatedTextFragment == null;
 
             protected override string HttpPath()
             {
@@ -276,22 +288,25 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedTextFragment = ListenerMethods.CreatedTextFragment;
-            }
         }
     }
 
     public static partial class Put
     {
+
+
         public class V1_Editions_EditionId_TextFragments_TextFragmentId
-            : RequestObject<UpdateTextFragmentDTO, TextFragmentDataDTO>
+        : RequestObject<UpdateTextFragmentDTO, TextFragmentDataDTO>
         {
             private readonly uint _editionId;
-            private readonly UpdateTextFragmentDTO _payload;
             private readonly uint _textFragmentId;
+            private readonly UpdateTextFragmentDTO _payload;
+
+            public class Listeners
+            {
+                public ListenerMethods CreatedTextFragment = ListenerMethods.CreatedTextFragment;
+            };
+            public Listeners AvailableListeners { get; }
 
             /// <summary>
             ///     Updates the specified text fragment with the submitted properties
@@ -300,37 +315,23 @@ namespace SQE.ApiTest.ApiRequests
             /// <param name="textFragmentId">Id of the text fragment being updates</param>
             /// <param name="updatedTextFragment">Details of the updated text fragment</param>
             /// <returns>The details of the updated text fragment</returns>
-            public V1_Editions_EditionId_TextFragments_TextFragmentId(uint editionId, uint textFragmentId,
-                UpdateTextFragmentDTO payload)
+            public V1_Editions_EditionId_TextFragments_TextFragmentId(uint editionId, uint textFragmentId, UpdateTextFragmentDTO payload)
                 : base(payload)
             {
                 _editionId = editionId;
                 _textFragmentId = textFragmentId;
                 _payload = payload;
                 AvailableListeners = new Listeners();
-                _listenerDict.Add(ListenerMethods.CreatedTextFragment,
-                    (CreatedTextFragmentIsNull, CreatedTextFragmentListener));
+                _listenerDict.Add(ListenerMethods.CreatedTextFragment, (CreatedTextFragmentIsNull, CreatedTextFragmentListener));
             }
-
-            public Listeners AvailableListeners { get; }
 
             public TextFragmentDataDTO CreatedTextFragment { get; private set; }
-
-            private void CreatedTextFragmentListener(HubConnection signalrListener)
-            {
-                signalrListener.On<TextFragmentDataDTO>("CreatedTextFragment",
-                    receivedData => CreatedTextFragment = receivedData);
-            }
-
-            private bool CreatedTextFragmentIsNull()
-            {
-                return CreatedTextFragment == null;
-            }
+            private void CreatedTextFragmentListener(HubConnection signalrListener) => signalrListener.On<TextFragmentDataDTO>("CreatedTextFragment", receivedData => CreatedTextFragment = receivedData);
+            private bool CreatedTextFragmentIsNull() => CreatedTextFragment == null;
 
             protected override string HttpPath()
             {
-                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}")
-                    .Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
+                return RequestPath.Replace("/edition-id", $"/{_editionId.ToString()}").Replace("/text-fragment-id", $"/{_textFragmentId.ToString()}");
             }
 
             public override Func<HubConnection, Task<T>> SignalrRequest<T>()
@@ -344,11 +345,7 @@ namespace SQE.ApiTest.ApiRequests
                     return _editionId;
                 }
             }
-
-            public class Listeners
-            {
-                public ListenerMethods CreatedTextFragment = ListenerMethods.CreatedTextFragment;
-            }
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/UserRequests.cs
+++ b/sqe-api-test/ApiRequests/UserRequests.cs
@@ -11,17 +11,39 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Get
     {
+
+
         public class V1_Users
-            : RequestObject<EmptyInput, UserDTO>
+        : RequestObject<EmptyInput, UserDTO>
         {
+
+
+
+
+            /// <summary>
+            ///     Provides the user details for a user with valid JWT in the Authorize header
+            /// </summary>
+            /// <returns>A UserDTO for user account.</returns>
+            public V1_Users()
+
+            {
+
+
+            }
+
+
+
             protected override string HttpPath()
             {
                 return RequestPath;
@@ -31,15 +53,54 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString());
             }
+
+
+        }
+
+        public class V1_Users_DataStore
+        : RequestObject<EmptyInput, UserDataStoreDTO>
+        {
+
+
+
+
+            /// <summary>
+            /// Retrieve the information in the user's personal data store
+            /// </summary>
+            /// <param name="data">A JSON object with the data to store for the user</param>
+            /// <returns></returns>
+            public V1_Users_DataStore()
+
+            {
+
+
+            }
+
+
+
+            protected override string HttpPath()
+            {
+                return RequestPath;
+            }
+
+            public override Func<HubConnection, Task<T>> SignalrRequest<T>()
+            {
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString());
+            }
+
+
         }
     }
 
     public static partial class Post
     {
+
+
         public class V1_Users_Login
-            : RequestObject<LoginRequestDTO, DetailedUserTokenDTO>
+        : RequestObject<LoginRequestDTO, DetailedUserTokenDTO>
         {
             private readonly LoginRequestDTO _payload;
+
 
 
             /// <summary>
@@ -54,7 +115,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -66,12 +129,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users_ChangeUnactivatedEmail
-            : RequestObject<UnactivatedEmailUpdateRequestDTO, EmptyOutput>
+        : RequestObject<UnactivatedEmailUpdateRequestDTO, EmptyOutput>
         {
             private readonly UnactivatedEmailUpdateRequestDTO _payload;
+
 
 
             /// <summary>
@@ -83,7 +149,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -95,12 +163,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users_ChangeForgottenPassword
-            : RequestObject<ResetForgottenUserPasswordRequestDTO, EmptyOutput>
+        : RequestObject<ResetForgottenUserPasswordRequestDTO, EmptyOutput>
         {
             private readonly ResetForgottenUserPasswordRequestDTO _payload;
+
 
 
             /// <summary>
@@ -111,7 +182,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -123,12 +196,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users_ChangePassword
-            : RequestObject<ResetLoggedInUserPasswordRequestDTO, EmptyOutput>
+        : RequestObject<ResetLoggedInUserPasswordRequestDTO, EmptyOutput>
         {
             private readonly ResetLoggedInUserPasswordRequestDTO _payload;
+
 
 
             /// <summary>
@@ -139,7 +215,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -151,12 +229,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users_ConfirmRegistration
-            : RequestObject<AccountActivationRequestDTO, EmptyOutput>
+        : RequestObject<AccountActivationRequestDTO, EmptyOutput>
         {
             private readonly AccountActivationRequestDTO _payload;
+
 
 
             /// <summary>
@@ -168,7 +249,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -180,12 +263,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users_ForgotPassword
-            : RequestObject<ResetUserPasswordRequestDTO, EmptyOutput>
+        : RequestObject<ResetUserPasswordRequestDTO, EmptyOutput>
         {
             private readonly ResetUserPasswordRequestDTO _payload;
+
 
 
             /// <summary>
@@ -196,7 +282,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -208,12 +296,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users
-            : RequestObject<NewUserRequestDTO, UserDTO>
+        : RequestObject<NewUserRequestDTO, UserDTO>
         {
             private readonly NewUserRequestDTO _payload;
+
 
 
             /// <summary>
@@ -225,7 +316,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -237,12 +330,15 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
 
         public class V1_Users_ResendActivationEmail
-            : RequestObject<ResendUserAccountActivationRequestDTO, EmptyOutput>
+        : RequestObject<ResendUserAccountActivationRequestDTO, EmptyOutput>
         {
             private readonly ResendUserAccountActivationRequestDTO _payload;
+
 
 
             /// <summary>
@@ -254,7 +350,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -266,15 +364,20 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
     }
 
     public static partial class Put
     {
+
+
         public class V1_Users
-            : RequestObject<UserUpdateRequestDTO, DetailedUserDTO>
+        : RequestObject<UserUpdateRequestDTO, DetailedUserDTO>
         {
             private readonly UserUpdateRequestDTO _payload;
+
 
 
             /// <summary>
@@ -290,7 +393,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -302,6 +407,43 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
+        }
+
+        public class V1_Users_DataStore
+        : RequestObject<UserDataStoreDTO, EmptyOutput>
+        {
+            private readonly UserDataStoreDTO _payload;
+
+
+
+            /// <summary>
+            /// Update the information in the user's personal data store
+            /// </summary>
+            /// <param name="data">A JSON object with the data to store for the user</param>
+            /// <returns></returns>
+            public V1_Users_DataStore(UserDataStoreDTO payload)
+                : base(payload)
+            {
+                _payload = payload;
+
+            }
+
+
+
+            protected override string HttpPath()
+            {
+                return RequestPath;
+            }
+
+            public override Func<HubConnection, Task<T>> SignalrRequest<T>()
+            {
+                return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
+            }
+
+
         }
     }
+
 }

--- a/sqe-api-test/ApiRequests/UtilRequests.cs
+++ b/sqe-api-test/ApiRequests/UtilRequests.cs
@@ -11,18 +11,24 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using SQE.API.DTO;
 
 namespace SQE.ApiTest.ApiRequests
 {
+
+
     public static partial class Post
     {
+
+
         public class V1_Utils_RepairWktPolygon
-            : RequestObject<WktPolygonDTO, WktPolygonDTO>
+        : RequestObject<WktPolygonDTO, WktPolygonDTO>
         {
             private readonly WktPolygonDTO _payload;
+
 
 
             /// <summary>
@@ -35,7 +41,9 @@ namespace SQE.ApiTest.ApiRequests
                 : base(payload)
             {
                 _payload = payload;
+
             }
+
 
 
             protected override string HttpPath()
@@ -47,6 +55,9 @@ namespace SQE.ApiTest.ApiRequests
             {
                 return signalR => signalR.InvokeAsync<T>(SignalrRequestString(), _payload);
             }
+
+
         }
     }
+
 }

--- a/sqe-api-test/CatalogueTests.cs
+++ b/sqe-api-test/CatalogueTests.cs
@@ -85,34 +85,34 @@ namespace SQE.ApiTest
         }
 
         // TODO: the following test is correct, but the code in the API still needs to be fixed
-        // [Theory]
-        // [InlineData(true)]
-        // [InlineData(false)]
-        // public async Task CanConfirmAndUnconfirmImagedObjectTextFragmentMatch(bool realtime)
-        // {
-        //     // Arrange
-        //     const uint editionId = 894U;
-        //     var matches = await CatalogueHelpers.GetImagedObjectsAndTextFragmentsOfEdition(editionId, _client, StartConnectionAsync);
-        //     var firstUnconfirmedMatch = matches.matches.First(x => x.confirmed == null);
-        //
-        //     // Act
-        //     await CatalogueHelpers.ConfirmTextFragmentImagedObjectMatch(
-        //         editionId,
-        //         firstUnconfirmedMatch.matchId,
-        //         _client,
-        //         StartConnectionAsync,
-        //         realtime,
-        //         Request.DefaultUsers.User1);
-        //
-        //     await Task.Delay(150); // Wait a tiny amount of time so we don't go faster than MySQL Data resolution
-        //
-        //     await CatalogueHelpers.UnconfirmTextFragmentImagedObjectMatch(
-        //         editionId,
-        //         firstUnconfirmedMatch.matchId,
-        //         _client,
-        //         StartConnectionAsync,
-        //         realtime,
-        //         Request.DefaultUsers.User1);
-        // }
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanConfirmAndUnconfirmImagedObjectTextFragmentMatch(bool realtime)
+        {
+            // Arrange
+            const uint editionId = 894U;
+            var matches = await CatalogueHelpers.GetImagedObjectsAndTextFragmentsOfEdition(editionId, _client, StartConnectionAsync);
+            var firstUnconfirmedMatch = matches.matches.First(x => x.confirmed == null);
+
+            // Act
+            await CatalogueHelpers.ConfirmTextFragmentImagedObjectMatch(
+                editionId,
+                firstUnconfirmedMatch.matchId,
+                _client,
+                StartConnectionAsync,
+                realtime,
+                Request.DefaultUsers.User1);
+
+            await Task.Delay(150); // Wait a tiny amount of time so we don't go faster than MySQL Data resolution
+
+            await CatalogueHelpers.UnconfirmTextFragmentImagedObjectMatch(
+                editionId,
+                firstUnconfirmedMatch.matchId,
+                _client,
+                StartConnectionAsync,
+                realtime,
+                Request.DefaultUsers.User1);
+        }
     }
 }

--- a/sqe-api-test/EditionTests.cs
+++ b/sqe-api-test/EditionTests.cs
@@ -1006,7 +1006,6 @@ namespace SQE.ApiTest
             Assert.True(msg.editions.Count > 0);
         }
 
-        // TODO: finish updating test to use new request objects.
         /// <summary>
         ///     Check if we can get editions when unauthenticated
         /// </summary>
@@ -1016,21 +1015,23 @@ namespace SQE.ApiTest
         public async Task GetOneEditionUnauthenticated()
         {
             // ARRANGE
-            const string url = "/v1/editions/1";
+            const uint editionId = 1;
+            const string necessaryCCLicenseText =
+            @"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. 
+To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/legalcode 
+or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.";
 
             // Act
-            var (response, msg) = await Request.SendHttpRequestAsync<string, EditionGroupDTO>(
-                _client,
-                HttpMethod.Get,
-                url,
-                null
-            );
-            response.EnsureSuccessStatusCode();
+            var editionRequest = new Get.V1_Editions_EditionId(editionId);
+            await editionRequest.SendAsync(_client, StartConnectionAsync);
+            editionRequest.HttpResponseMessage.EnsureSuccessStatusCode();
 
             // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
-            Assert.NotNull(msg.primary.name);
+            Assert.Equal("application/json; charset=utf-8", editionRequest.HttpResponseMessage.Content.Headers.ContentType.ToString());
+            Assert.NotNull(editionRequest.HttpResponseObject.primary.name);
+            Assert.NotNull(editionRequest.HttpResponseObject.primary.copyright);
+            // Confirm we are transmitting the necessary CC-BY-SA license
+            Assert.Contains(necessaryCCLicenseText, editionRequest.HttpResponseObject.primary.copyright);
         }
 
         // TODO: finish updating test to use new request objects.

--- a/sqe-api-test/Helpers/UserHelpers.cs
+++ b/sqe-api-test/Helpers/UserHelpers.cs
@@ -110,13 +110,15 @@ namespace SQE.ApiTest.Helpers
         private static async Task CleanupUserAccountAsync(UserDTO user, DatabaseQuery db)
         {
             const string deleteNewUserSql = "DELETE FROM user WHERE email = @Email";
-            const string deleteUserRoleSQL = "DELETE FROM users_system_roles WHERE user_id = @UserID";
+            const string deleteUserRoleSql = "DELETE FROM users_system_roles WHERE user_id = @UserID";
+            const string deleteUserDataSql = "DELETE FROM SQE.user_data_store WHERE user_id = @UserID";
             const string deleteEmailTokenSql = "DELETE FROM user_email_token WHERE user_id = @UserId";
             var deleteEmailTokenParams = new DynamicParameters();
             deleteEmailTokenParams.Add("@UserId", user.userId);
             deleteEmailTokenParams.Add("@Email", user.email);
             await db.RunExecuteAsync(deleteEmailTokenSql, deleteEmailTokenParams);
-            await db.RunExecuteAsync(deleteUserRoleSQL, deleteEmailTokenParams);
+            await db.RunExecuteAsync(deleteUserRoleSql, deleteEmailTokenParams);
+            await db.RunExecuteAsync(deleteUserDataSql, deleteEmailTokenParams);
             await db.RunExecuteAsync(deleteNewUserSql, deleteEmailTokenParams);
         }
 

--- a/sqe-api-test/UserTests.cs
+++ b/sqe-api-test/UserTests.cs
@@ -896,7 +896,7 @@ namespace SQE.ApiTest
         public async Task CanWriteToUserDataStore(bool realtime)
         {
             const string data = "{\"data\":\"good stuff\"}";
-            WriteToUserDataStore(realtime, data, true, null);
+            await WriteToUserDataStore(realtime, data, true, null);
         }
 
         [Theory]
@@ -906,7 +906,7 @@ namespace SQE.ApiTest
         public async Task CanNotWriteInvalidJsonToUserDataStore(bool realtime)
         {
             const string data = "{\"data\":bad stuff\"}";
-            WriteToUserDataStore(realtime, data, false, HttpStatusCode.BadRequest);
+            await WriteToUserDataStore(realtime, data, false, HttpStatusCode.BadRequest);
         }
 
         [Theory]
@@ -917,10 +917,10 @@ namespace SQE.ApiTest
         {
             var longString = new string('a', 10000010);
             var data = $"{{\"data\":\"{longString}\"}}";
-            WriteToUserDataStore(realtime, longString, false, HttpStatusCode.BadRequest);
+            await WriteToUserDataStore(realtime, longString, false, HttpStatusCode.BadRequest);
         }
 
-        public async Task WriteToUserDataStore(bool realtime, string dataString, bool shouldSucceed, HttpStatusCode? expectedError)
+        private async Task WriteToUserDataStore(bool realtime, string dataString, bool shouldSucceed, HttpStatusCode? expectedError)
         {
             // Arrange
             var dataObj = new UserDataStoreDTO()

--- a/sqe-api-test/UserTests.cs
+++ b/sqe-api-test/UserTests.cs
@@ -917,7 +917,7 @@ namespace SQE.ApiTest
         {
             var longString = new string('a', 10000010);
             var data = $"{{\"data\":\"{longString}\"}}";
-            await WriteToUserDataStore(realtime, longString, false, HttpStatusCode.BadRequest);
+            await WriteToUserDataStore(realtime, data, false, HttpStatusCode.BadRequest);
         }
 
         private async Task WriteToUserDataStore(bool realtime, string dataString, bool shouldSucceed, HttpStatusCode? expectedError)

--- a/sqe-database-access/EditionRepository.cs
+++ b/sqe-database-access/EditionRepository.cs
@@ -104,7 +104,7 @@ namespace SQE.DatabaseAccess
                                 ManuscriptMetricsEditor = editionGroup.ManuscriptMetricsEditor,
                                 Collaborators = editionGroup.Collaborators,
                                 Copyright =
-                                    null, //Licence.printLicence(editionGroup.CopyrightHolder, editionGroup.Collaborators),
+                                    null,//Licence.printLicence(editionGroup.CopyrightHolder, editionGroup.Collaborators),
                                 CopyrightHolder = editionGroup.CopyrightHolder,
                                 EditionDataEditorId = editionGroup.EditionDataEditorId,
                                 EditionId = editionGroup.EditionId,

--- a/sqe-database-access/Helpers/Licence.cs
+++ b/sqe-database-access/Helpers/Licence.cs
@@ -1,3 +1,9 @@
+using System.Collections.Generic;
+using System.IO.Enumeration;
+using System.Linq;
+using MySqlX.XDevAPI;
+using SQE.DatabaseAccess.Models;
+
 namespace SQE.DatabaseAccess.Helpers
 {
     // TODO We still have to find a final formulation.
@@ -11,14 +17,56 @@ namespace SQE.DatabaseAccess.Helpers
 To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/legalcode 
 or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.";
 
-        public static string printLicence(string copyrightHolder, string contributors)
+        /// <summary>
+        /// Formats a license statement from the submitted information. All licenses must be at least
+        /// as permissive as CC-BY-SA within the Qumranica database due to its internal operational
+        /// characteristics. This code ensures that all data sent from this API clearly conveys the
+        /// necessary license.
+        /// </summary>
+        /// <param name="copyrightHolder">Name of the individual or organization holding the copyright</param>
+        /// <param name="contributors">A list of all contributors</param>
+        /// <param name="editors">An optional list of editors that can be used to automatically
+        /// generate a list of contributors if the contributors variable is null.</param>
+        /// <returns>A formatted license statement</returns>
+        public static string printLicence(string copyrightHolder, string contributors, IEnumerable<EditorInfo> editors = null)
         {
+            var formattedEditors = editors == null
+                ? ""
+                : string.Join(", ", editors.Select(FormatEditorName));
+            contributors ??= formattedEditors;
             return $@"© {copyrightHolder} 
 
-Provided by {contributors} on the basis of a text provided by the Qumran-Wörterbuch of the Göttingen Academy of Sciences, 
-which is based upon a preliminary text provided Martin Abegg.
+Provided by {AddAndToLastComma(contributors)} on the basis of a text provided by the Qumran-Wörterbuch of the Göttingen Academy of Sciences, 
+which is based upon a preliminary text provided by Martin Abegg.
 
 {licenceText}";
         }
+
+        /// <summary>
+        /// Examines the editor info and provides a human readable version
+        /// of the editor's name.
+        /// </summary>
+        /// <param name="editor">Details of the editor</param>
+        /// <returns>A string with the editors formatted name</returns>
+        private static string FormatEditorName(EditorInfo editor)
+        {
+            return $@"{editor.Forename} {editor.Surname}".Trim();
+        }
+
+        /// <summary>
+        /// Examine a string and add " and" after the last comma.
+        /// This makes lists more human readable.
+        /// </summary>
+        /// <param name="text">The text to process</param>
+        /// <returns>A string with " and" added after the last comma</returns>
+        private static string AddAndToLastComma(string text)
+        {
+            var idxOfLastComma = text.LastIndexOf(',');
+            return idxOfLastComma != -1
+                ? text.Remove(idxOfLastComma, 1).Insert(idxOfLastComma, ", and")
+                : text;
+        }
     }
+
+
 }

--- a/sqe-database-access/Queries/CatalogueQueries.cs
+++ b/sqe-database-access/Queries/CatalogueQueries.cs
@@ -75,7 +75,8 @@ JOIN (
 ) AS iecc2 ON iecc2.iaa_edition_catalog_to_text_fragment_id = image_text_fragment_match_catalogue.iaa_edition_catalog_to_text_fragment_id";
 
         private const string allFilter =
-            @"JOIN SQE.iaa_edition_catalog_to_text_fragment_confirmation AS iecc USING(iaa_edition_catalog_to_text_fragment_id)";
+            @"JOIN SQE.iaa_edition_catalog_to_text_fragment_confirmation AS iecc1 USING(iaa_edition_catalog_to_text_fragment_id)
+JOIN SQE.iaa_edition_catalog_to_text_fragment_confirmation AS iecc2 USING(iaa_edition_catalog_to_text_fragment_id)";
 
         private const string editionFilter = "WHERE image_text_fragment_match_catalogue.edition_id = @EditionId";
 

--- a/sqe-database-access/Queries/UserQueries.cs
+++ b/sqe-database-access/Queries/UserQueries.cs
@@ -257,4 +257,30 @@ JOIN user_email_token ON user_email_token.token = @Token
 WHERE system_roles.role_title = @SystemRole
 ON DUPLICATE KEY UPDATE user_id = VALUES(user_id)";
     }
+
+    internal static class CreateUserDataStoreEntry
+    {
+        public const string GetQuery = @"
+INSERT INTO user_data_store (user_id, data)
+SELECT user_id, @Data
+FROM user_email_token
+WHERE user_email_token.token = @Token
+ON DUPLICATE KEY UPDATE data=@Data";
+    }
+
+    internal static class GetInformationFromUserDataStore
+    {
+        public const string GetQuery = @"
+SELECT data
+FROM user_data_store
+WHERE user_id = @UserId";
+    }
+
+    internal static class SetInformationInUserDataStore
+    {
+        public const string GetQuery = @"
+UPDATE user_data_store
+SET data = @Data
+WHERE user_id = @UserId";
+    }
 }

--- a/sqe-dto/User.cs
+++ b/sqe-dto/User.cs
@@ -159,6 +159,8 @@ namespace SQE.API.DTO
     public class UserDataStoreDTO
     {
         [Required]
+        [StringLength(1000000, MinimumLength = 2,
+            ErrorMessage = "The submitted data may not be larger than 1000000 character")]
         public string data { get; set; }
     }
 

--- a/sqe-dto/User.cs
+++ b/sqe-dto/User.cs
@@ -156,5 +156,11 @@ namespace SQE.API.DTO
         public string organization { get; set; }
     }
 
+    public class UserDataStoreDTO
+    {
+        [Required]
+        public string data { get; set; }
+    }
+
     #endregion Response DTO's
 }

--- a/ts-dtos/sqe-dtos.ts
+++ b/ts-dtos/sqe-dtos.ts
@@ -531,6 +531,10 @@ export interface EditorDTO {
     organization?: string;
 }
 
+export interface UserDataStoreDTO {
+    data: string;
+}
+
 export interface ImageStackDTO {
     id?: number;
     images: Array<ImageDTO>;

--- a/ts-dtos/sqe-signalr.ts
+++ b/ts-dtos/sqe-signalr.ts
@@ -102,6 +102,7 @@ import {
 	DetailedUserDTO,
 	DetailedUserTokenDTO,
 	EditorDTO,
+	UserDataStoreDTO,
 	ImageStackDTO,
 	ImagedObjectDTO,
 	ImagedObjectListDTO,
@@ -585,6 +586,26 @@ export class SignalRUtilities {
 	 */
     public async postV1UsersResendActivationEmail(payload: ResendUserAccountActivationRequestDTO): Promise<void> {
         return await this._connection.invoke('PostV1UsersResendActivationEmail', payload);
+    }
+
+    /**
+	 * Retrieve the information in the user's personal data store
+	 *
+	 * @param data - A JSON object with the data to store for the user
+	 *
+	 */
+    public async getV1UsersDataStore(): Promise<UserDataStoreDTO> {
+        return await this._connection.invoke('GetV1UsersDataStore');
+    }
+
+    /**
+	 * Update the information in the user's personal data store
+	 *
+	 * @param data - A JSON object with the data to store for the user
+	 *
+	 */
+    public async putV1UsersDataStore(data: UserDataStoreDTO): Promise<void> {
+        return await this._connection.invoke('PutV1UsersDataStore', data);
     }
 
     /**

--- a/ts-dtos/sqe-signalr.ts
+++ b/ts-dtos/sqe-signalr.ts
@@ -591,7 +591,7 @@ export class SignalRUtilities {
     /**
 	 * Retrieve the information in the user's personal data store
 	 *
-	 * @param data - A JSON object with the data to store for the user
+	 *
 	 *
 	 */
     public async getV1UsersDataStore(): Promise<UserDataStoreDTO> {


### PR DESCRIPTION
This is a small PR (especially if you ignore the autogenerated stuff in the sqe-api-test/ApiRequests folder).  It adds the following functionality:

- Bugfix on user creation so that new users now get the proper default system role.
- Added support for the user_data_store in the database with a GET and PUT endpoint for users to add various user settings etc. (do what you will).  The API checks that the submitted data is less than one million characters long and also that it is a valid JSON string.  Let me know if you think we should change either of those—note that the JSON type of the database field probably allows about 1GB, which is way to much to allow for each user, so I wanted the API to restrict that somewhat.
- Some bugfixes in the catalogue endpoints and tests.
- Fixed the error of the license field being NULL in edition DTOs.