### PR TITLE
add blank email to text response

### DIFF
--- a/sqe-api-server/Services/TextService.cs
+++ b/sqe-api-server/Services/TextService.cs
@@ -179,6 +179,7 @@ namespace SQE.API.Server.Services
                 editors.ToDictionary(editor => editor.EditorId.ToString(),
                     editor => new EditorDTO
                     {
+                        email = "", // For now we will hide the email address for privacy
                         forename = editor.Forename,
                         surname = editor.Surname,
                         organization = editor.Organization
@@ -335,6 +336,7 @@ namespace SQE.API.Server.Services
                     editor => editor.EditorId.ToString(),
                     editor => new EditorDTO
                     {
+                        email = "", // For now we will hide the email address for privacy
                         forename = editor.Forename,
                         surname = editor.Surname,
                         organization = editor.Organization


### PR DESCRIPTION
Here's a real tiny PR.  I am catching some little edge issues while using the new Python library `https://pypi.org/project/qumranica/`.  Apparently the guard like `[Required]` in the DTO's are not checked when you create an object with `var myDTO = new coolDTO() { val = "something"}`, perhaps those only work when you create an object via a constructor.

I am still looking into a super rigid linter, so we get rid of formatting noise, and your recommendation to turn off review for auto-generated files. 